### PR TITLE
applySearchClauses respect existing where clauses

### DIFF
--- a/src/Table.php
+++ b/src/Table.php
@@ -359,22 +359,24 @@ class Table implements Htmlable
     protected function applySearchClauses(Builder $query): void
     {
         if ($searched = $this->request->search) {
-            $this->searchableColumns->map(function (Column $column, int $columnKey) use (&$query, $searched) {
-                $searchedDatabaseTable = $column->searchedDatabaseTable
+            $query->where(function ($q) use ($searched) {
+                $this->searchableColumns->map(function (Column $column, int $columnKey) use (&$q, $searched) {
+                    $searchedDatabaseTable = $column->searchedDatabaseTable
                     ? $column->searchedDatabaseTable
                     : $column->databaseDefaultTable;
-                $operator = $columnKey > 0 ? 'orWhere' : 'where';
-                $searchedDatabaseColumns = $column->searchedDatabaseColumns
+                    $operator = $columnKey > 0 ? 'orWhere' : 'where';
+                    $searchedDatabaseColumns = $column->searchedDatabaseColumns
                     ? $column->searchedDatabaseColumns
                     : [$column->attribute];
-                foreach ($searchedDatabaseColumns as $searchedDatabaseColumnKey => $searchedDatabaseColumn) {
-                    $operator = $searchedDatabaseColumnKey > 0 ? 'orWhere' : $operator;
-                    $query->{$operator}(
-                        $searchedDatabaseTable . '.' . $searchedDatabaseColumn,
-                        'like',
-                        '%' . $searched . '%'
-                    );
-                }
+                    foreach ($searchedDatabaseColumns as $searchedDatabaseColumnKey => $searchedDatabaseColumn) {
+                        $operator = $searchedDatabaseColumnKey > 0 ? 'orWhere' : $operator;
+                        $q->{$operator}(
+                            $searchedDatabaseTable . '.' . $searchedDatabaseColumn,
+                            'like',
+                            '%' . $searched . '%'
+                        );
+                    }
+                });
             });
         }
     }


### PR DESCRIPTION
I'm migrating a project over to laravel-table now that laravel-bootstrap-table-list is deprecated.

An issue I encountered is that the query was incorrect when searching. Essentially, `applySearchClauses` appended additional `or` clauses which effectively cancelled out the original `where` clause. This pull request updates `applySearchClauses` so that the search clauses are wrapped in a subquery.

Example:
```php
$org_id = 3; // from elsewhere
$table = 
            // ... snip
            ->query(function ($query) use ($org_id) {
                $query->select('bank_accounts.*');
                $query->join('users', 'users.id', '=', 'bank_accounts.created_by');
                $query->where('bank_accounts.org_id', $org_id);
            });
// ... snip
```

SQL Before
```sql
select ... where `bank_accounts`.`org_id` = 3 and `bank_accounts`.`id` like '%om%' or `bank_accounts`.`title` like '%om%' or `users`.`name` like '%om%' order by `id` asc limit 20 offset 0
```

SQL After
```sql
select ... where `bank_accounts`.`org_id` = 3 and (`bank_accounts`.`id` like '%om%' or `bank_accounts`.`title` like '%om%' or `users`.`name` like '%om%') order by `id` asc limit 20 offset 0
```