### PR TITLE
1.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [1.2.5](https://github.com/Okipa/laravel-table/releases/tag/1.2.5)
+
+2019-10-14
+
+- Fixed the translations publication and overriding as specified on the Laravel documentation : https://laravel.com/docs/.7/packages#translations.
+- Changed the command to publish the translations to : `php artisan vendor:publish --tag=laravel-table:translations`
+- Changed the command to publish the configuration to : `php artisan vendor:publish --tag=laravel-table:config`
+- Changed the command to publish the views to : `php artisan vendor:publish --tag=laravel-table:views`
+- Improved testing with Travis CI (added some tests with `--prefer-lowest` composer tag to check the package compatibility with the lowest dependencies versions).
+
 ## [1.2.4](https://github.com/Okipa/laravel-table/releases/tag/1.2.4)
 
 2019-10-09

--- a/README.md
+++ b/README.md
@@ -97,17 +97,17 @@ Then, override the `config/laravel-table.php` file with you own configuration va
 You can customize the package translation by publishing them in your project :
 
 ```bash
-php artisan vendor:publish --tag=laravel-table::translations
+php artisan vendor:publish --tag=laravel-table:translations
 ```
 
-Once you have published them, override them from your `resources/lang/[locale]\laravel-table.php` directory.
+Once you have published them, override them from your `resources/lang/vendor/laravel-table/<locale>/laravel-table.php` directory.
 
 ## Customize templates
 
 To modify or use your own template, you will have to publish the package blade templates in your project :
 
 ```bash
-php artisan vendor:publish --tag=laravel-table::views
+php artisan vendor:publish --tag=laravel-table:views
 ```
 
 Then, play with the templates in your `resources/views/vendor/laravel-table` directory.

--- a/src/LaravelTableServiceProvider.php
+++ b/src/LaravelTableServiceProvider.php
@@ -14,13 +14,13 @@ class LaravelTableServiceProvider extends ServiceProvider
         $this->loadTranslationsFrom(__DIR__ . '/../lang', 'laravel-table');
         $this->publishes([
             __DIR__ . '/../config/laravel-table.php' => config_path('laravel-table.php'),
-        ], 'laravel-table::config');
+        ], 'laravel-table:config');
         $this->publishes([
-            __DIR__ . '/../lang' => resource_path('lang'),
-        ], 'laravel-table::translations');
+            __DIR__ . '/../lang' => resource_path('lang/vendor/laravel-table'),
+        ], 'laravel-table:translations');
         $this->publishes([
             __DIR__ . '/../views' => resource_path('views/vendor/laravel-table'),
-        ], 'laravel-table::views');
+        ], 'laravel-table:views');
         // we load the laravel html helper package
         // https://github.com/Okipa/laravel-html-helper
         $this->app->register(HtmlHelperServiceProvider::class);


### PR DESCRIPTION
- Fixed the translations publication and overriding as specified on the Laravel documentation : https://laravel.com/docs/.7/packages#translations.
- Changed the command to publish the translations to : `php artisan vendor:publish --tag=laravel-table:translations`
- Changed the command to publish the configuration to : `php artisan vendor:publish --tag=laravel-table:config`
- Changed the command to publish the views to : `php artisan vendor:publish --tag=laravel-table:views`
- Improved testing with Travis CI (added some tests with `--prefer-lowest` composer tag to check the package compatibility with the lowest dependencies versions).