### PR TITLE
Fix missing column for show route

### DIFF
--- a/src/Table.php
+++ b/src/Table.php
@@ -248,7 +248,7 @@ class Table implements Htmlable
      */
     public function columnsCount(): int
     {
-        $extraColumnsCount = $this->isRouteDefined('edit') || $this->isRouteDefined('destroy') ? 1 : 0;
+        $extraColumnsCount = $this->isRouteDefined('show') || $this->isRouteDefined('edit') || $this->isRouteDefined('destroy') ? 1 : 0;
 
         return $this->columns->count() + $extraColumnsCount;
     }

--- a/views/bootstrap/thead.blade.php
+++ b/views/bootstrap/thead.blade.php
@@ -120,7 +120,7 @@
                 @endif
             </th>
         @endforeach
-        @if($table->isRouteDefined('edit') || $table->isRouteDefined('destroy'))
+        @if($table->isRouteDefined('show') || $table->isRouteDefined('edit') || $table->isRouteDefined('destroy'))
             <th{{ classTag('text-right', $table->thClasses) }} scope="col">
                 @lang('laravel-table::laravel-table.actions')
             </th>


### PR DESCRIPTION
If you use `show` route it alone without `edit` or `destroy`, there is an empty column in the rows, so with this merge, it will fix.

```
$table = (new Table)->model(UserModel::class)->routes([
            'index' => ['name' => 'user.list'],
            'create' => ['name' => 'user.create.index'],
            'show' => ['name' => 'user.show'],
        ]);
```