### PR TITLE
1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [1.4.0](https://github.com/Okipa/laravel-table/compare/1.3.0...1.4.0)
+
+2020-04-26
+
+* Added more granularity in the template customization possibilities : the `show`, `edit` and `destroy` actions are now defined in their own component. This way, it becomes easier to customize tiny parts of the table without touching to the others.
+  * Added `config('laravel-table.template.show')`, `config('laravel-table.template.edit')` and `config('laravel-table.template.destroy')` configs to set each new default component path.
+  * Added `->showTemplate()`, `->editTemplate()` and `->destroyTemplate()` to give the ability to customize these templates on the fly.
+* Added fallback path for each template if the config value is not defined, in order to prevent any update breaking change.
+
 ## [1.3.0](https://github.com/Okipa/laravel-table/compare/1.2.7...1.3.0)
 
 2020-04-25

--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@ Then, display it in the view:
   * [->tableTemplate()](#table-tableTemplate)
   * [->theadTemplate()](#table-theadTemplate)
   * [->tbodyTemplate()](#table-tbodyTemplate)
+  * [->showTemplate()](#table-showTemplate)
+  * [->editTemplate()](#table-editTemplate)
+  * [->destroyTemplate()](#table-destroyTemplate)
   * [->resultsTemplate()](#table-resultsTemplate)
   * [->tfootTemplate()](#table-tfootTemplate)
   * [->column()](#table-column)
@@ -514,7 +517,7 @@ destroyButton.click((e) => {
 
 **Note:**
 
-* Signature: `tableTemplate(string $tableComponentPath): \Okipa\LaravelTable\Table`
+* Signature: `tableTemplate(string $tableTemplatePath): \Okipa\LaravelTable\Table`
 * Optional
 
 **Use case example:**
@@ -530,7 +533,7 @@ destroyButton.click((e) => {
 
 **Note:**
 
-* Signature: `theadTemplate(string $theadComponentPath): \Okipa\LaravelTable\Table`
+* Signature: `theadTemplate(string $theadTemplatePath): \Okipa\LaravelTable\Table`
 * Optional
 
 **Use case example:**
@@ -546,13 +549,61 @@ destroyButton.click((e) => {
 
 **Note:**
 
-* Signature: `tbodyTemplate(string $tbodyComponentPath): \Okipa\LaravelTable\Table`
+* Signature: `tbodyTemplate(string $tbodyTemplatePath): \Okipa\LaravelTable\Table`
 * Optional
 
 **Use case example:**
 
 ```php
 (new Table)->tbodyTemplate('tailwindCss.tbody');
+```
+
+<h3 id="table-showTemplate">->showTemplate()</h3>
+
+> Set a custom template path for the show component.  
+> The default show template path is defined in the `config('laravel-table.template.show')` config value.
+
+**Note:**
+
+* Signature: `showTemplate(string $showTemplatePath): \Okipa\LaravelTable\Table`
+* Optional
+
+**Use case example:**
+
+```php
+(new Table)->showTemplate('tailwindCss.show');
+```
+
+<h3 id="table-editTemplate">->editTemplate()</h3>
+
+> Set a custom template path for the edit component.  
+> The default edit template path is defined in the `config('laravel-table.template.edit')` config value.
+
+**Note:**
+
+* Signature: `editTemplate(string $editTemplatePath): \Okipa\LaravelTable\Table`
+* Optional
+
+**Use case example:**
+
+```php
+(new Table)->editTemplate('tailwindCss.edit');
+```
+
+<h3 id="table-destroyTemplate">->destroyTemplate()</h3>
+
+> Set a custom template path for the destroy component.  
+> The default destroy template path is defined in the `config('laravel-table.template.destroy')` config value.
+
+**Note:**
+
+* Signature: `destroyTemplate(string $destroyTemplatePath): \Okipa\LaravelTable\Table`
+* Optional
+
+**Use case example:**
+
+```php
+(new Table)->destroyTemplate('tailwindCss.destroy');
 ```
 
 <h3 id="table-resultsTemplate">->resultsTemplate()</h3>

--- a/config/laravel-table.php
+++ b/config/laravel-table.php
@@ -3,7 +3,7 @@
 return [
 
     /*
-     * Default classes for each table parts.
+     * Default classes for each table part.
      */
     'classes' => [
         'container' => ['table-responsive'],
@@ -34,7 +34,7 @@ return [
     ],
 
     /*
-     * Default table values
+     * Default table configuration.
      */
     'value' => [
         'rowsNumber' => 20,
@@ -42,12 +42,15 @@ return [
     ],
 
     /*
-     * Default template paths for each table parts.
+     * Default template path for each table part.
      */
     'template' => [
         'table' => 'bootstrap.table',
         'thead' => 'bootstrap.thead',
         'tbody' => 'bootstrap.tbody',
+        'show' => 'bootstrap.show',
+        'edit' => 'bootstrap.edit',
+        'destroy' => 'bootstrap.destroy',
         'results' => 'bootstrap.results',
         'tfoot' => 'bootstrap.tfoot',
     ],

--- a/lang/en/laravel-table.php
+++ b/lang/en/laravel-table.php
@@ -4,7 +4,7 @@ return [
 
     'rowsNumber'   => 'Rows number',
     'emptyTable'   => 'No results were found.',
-    'search'       => 'Search by :',
+    'search'       => 'Search by:',
     'cancelSearch' => 'Cancel research',
     'actions'      => 'Actions',
     'create'       => 'Create',

--- a/src/Column.php
+++ b/src/Column.php
@@ -42,10 +42,10 @@ class Column
     /** @property string $url */
     public $url;
 
-    /** @property Closure $valueClosure */
+    /** @property \Closure $valueClosure */
     public $valueClosure;
 
-    /** @property Closure $htmlClosure */
+    /** @property \Closure $htmlClosure */
     public $htmlClosure;
 
     /** @property string $icon */
@@ -234,7 +234,7 @@ class Column
      * The closure let you manipulate the following attributes : \Illuminate\Database\Eloquent\Model $model,
      * \Okipa\LaravelTable\Column$column.
      *
-     * @param Closure $valueClosure
+     * @param \Closure $valueClosure
      *
      * @return \Okipa\LaravelTable\Column
      */
@@ -250,7 +250,7 @@ class Column
      * The closure let you manipulate the following attributes : \Illuminate\Database\Eloquent\Model $model,
      * \Okipa\LaravelTable\Column $column.
      *
-     * @param Closure $htmlClosure
+     * @param \Closure $htmlClosure
      *
      * @return \Okipa\LaravelTable\Column
      */

--- a/src/LaravelTableServiceProvider.php
+++ b/src/LaravelTableServiceProvider.php
@@ -2,7 +2,6 @@
 
 namespace Okipa\LaravelTable;
 
-use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Support\ServiceProvider;
 use Okipa\LaravelHtmlHelper\HtmlHelperServiceProvider;
 

--- a/src/Result.php
+++ b/src/Result.php
@@ -6,8 +6,13 @@ use Closure;
 
 class Result
 {
+    /** @property string $title */
     public $title;
+
+    /** @property \Closure $htmlClosure */
     public $htmlClosure;
+
+    /** @property array $classes */
     public $classes;
 
     /**
@@ -36,7 +41,7 @@ class Result
      * Display a HTML output for the result row.
      * The closure let you manipulate the following attributes : \Illuminate\Support\Collection $displayedList.
      *
-     * @param Closure $htmlClosure
+     * @param \Closure $htmlClosure
      *
      * @return \Okipa\LaravelTable\Result
      */

--- a/src/Table.php
+++ b/src/Table.php
@@ -389,7 +389,7 @@ class Table implements Htmlable
         $this->handleRequestInteractionValues();
         $this->generateEntitiesListFromQuery();
 
-        return view('laravel-table::' . $this->tableComponentPath, ['table' => $this]);
+        return view('laravel-table::' . $this->tableTemplatePath, ['table' => $this]);
     }
 
     /**

--- a/src/Table.php
+++ b/src/Table.php
@@ -48,7 +48,7 @@ class Table implements Htmlable
     /** @property \Illuminate\Support\Collection $columns */
     public $columns;
 
-    /** @property Closure $queryClosure */
+    /** @property \Closure $queryClosure */
     public $queryClosure;
 
     /** @property \Illuminate\Support\Collection $disableRows */
@@ -57,7 +57,7 @@ class Table implements Htmlable
     /** @property \Illuminate\Pagination\LengthAwarePaginator $list */
     public $list;
 
-    /** @property Closure $destroyConfirmationClosure */
+    /** @property \Closure $destroyConfirmationClosure */
     public $destroyConfirmationClosure;
 
     /** @property array $appendedValues */
@@ -184,7 +184,7 @@ class Table implements Htmlable
      * Set the query closure that will be executed during the table generation.
      * The closure let you manipulate the following attribute : \Illuminate\Database\Eloquent\Builder $query.
      *
-     * @param Closure $queryClosure
+     * @param \Closure $queryClosure
      *
      * @return \Okipa\LaravelTable\Table
      */

--- a/src/Traits/TableClassesCustomizations.php
+++ b/src/Traits/TableClassesCustomizations.php
@@ -10,16 +10,22 @@ trait TableClassesCustomizations
 {
     /** @property array $containerClasses */
     public $containerClasses;
+
     /** @property array $tableClasses */
     public $tableClasses;
+
     /** @property array $trClasses */
     public $trClasses;
+
     /** @property array $thClasses */
     public $thClasses;
+
     /** @property array $tdClasses */
     public $tdClasses;
+
     /** @property array $resultClasses */
     public $resultClasses;
+
     /** @property array $rowsConditionalClasses */
     public $rowsConditionalClasses;
 
@@ -122,7 +128,7 @@ trait TableClassesCustomizations
      * The closure let you manipulate the following attribute : \Illuminate\Database\Eloquent\Model $model.
      *
      * @param \Closure $rowClassesClosure
-     * @param array    $rowClasses
+     * @param array $rowClasses
      *
      * @return \Okipa\LaravelTable\Table
      */

--- a/src/Traits/TableColumnsValidationChecks.php
+++ b/src/Traits/TableColumnsValidationChecks.php
@@ -31,7 +31,7 @@ trait TableColumnsValidationChecks
     {
         if (! $this->model instanceof Model) {
             $errorMessage = 'The table model has not been defined or is not an instance of « '
-                            . Model::class . ' ».';
+                . Model::class . ' ».';
             throw new ErrorException($errorMessage);
         }
     }
@@ -70,8 +70,8 @@ trait TableColumnsValidationChecks
     {
         if (! $column->databaseDefaultColumn && $column->isSortable) {
             $errorMessage = 'One of the sortable table columns has no defined database column. You have to define a '
-                            . 'database column for each sortable table columns by setting a string parameter in the '
-                            . '« column() » method.';
+                . 'database column for each sortable table columns by setting a string parameter in the '
+                . '« column() » method.';
             throw new ErrorException($errorMessage);
         }
     }
@@ -88,8 +88,8 @@ trait TableColumnsValidationChecks
     {
         if (! $column->databaseDefaultColumn) {
             $errorMessage = 'One of the searchable table columns has no defined database column. You have to define '
-                            . 'a database column for each searchable table columns by setting a string parameter in '
-                            . 'the « column() » method.';
+                . 'a database column for each searchable table columns by setting a string parameter in '
+                . 'the « column() » method.';
             throw new ErrorException($errorMessage);
         }
     }
@@ -114,9 +114,9 @@ trait TableColumnsValidationChecks
                     ? '« ' . $tableData['table'] . ' » (aliased as « ' . $tableAlias . ' ») table'
                     : '« ' . $tableData['table'] . ' » table';
                 $errorMessage = 'The table column with related « ' . $searchedDatabaseColumn . ' » database column is '
-                                . 'searchable and does not exist in the ' . $dynamicMessagePart
-                                . '. Set the database searched table and (optionally) columns with the « sortable() » '
-                                . 'method arguments.';
+                    . 'searchable and does not exist in the ' . $dynamicMessagePart
+                    . '. Set the database searched table and (optionally) columns with the « sortable() » '
+                    . 'method arguments.';
                 throw new ErrorException($errorMessage);
             }
         }
@@ -163,7 +163,7 @@ trait TableColumnsValidationChecks
     {
         if ($this->columns->isEmpty()) {
             $errorMessage = 'No column has been added to the table. Please add at least one column by using the '
-                            . '« column() » method on the table object.';
+                . '« column() » method on the table object.';
             throw new ErrorException($errorMessage);
         }
     }

--- a/src/Traits/TableInteractions.php
+++ b/src/Traits/TableInteractions.php
@@ -10,18 +10,25 @@ trait TableInteractions
 {
     /** @property int $rows */
     public $rows;
+
     /** @property bool $rowsField */
     public $rowsField = 'rows';
+
     /** @property string $sortBy */
     public $sortBy;
+
     /** @property string $sortByField */
     public $sortByField = 'sort_by';
+
     /** @property string $sortDir */
     public $sortDir;
+
     /** @property string $sortDirField */
     public $sortDirField = 'sort_dir';
+
     /** @property string $search */
     public $search;
+
     /** @property string $searchField */
     public $searchField = 'search';
 
@@ -52,16 +59,16 @@ trait TableInteractions
             $this->sortByField,
             $this->sortDirField
         ), [
-            $this->rowsField    => 'required|integer',
-            $this->searchField  => 'nullable|string',
-            $this->sortByField  => 'nullable|string|in:' . $this->columns->implode('databaseDefaultColumn', ','),
+            $this->rowsField => 'required|integer',
+            $this->searchField => 'nullable|string',
+            $this->sortByField => 'nullable|string|in:' . $this->columns->implode('databaseDefaultColumn', ','),
             $this->sortDirField => 'nullable|string|in:asc,desc',
         ]);
         if ($validator->fails()) {
             $this->request->merge([
-                $this->rowsField    => $this->rows ?? config('laravel-table.value.rows'),
-                $this->searchField  => null,
-                $this->sortByField  => $this->sortBy,
+                $this->rowsField => $this->rows ?? config('laravel-table.value.rows'),
+                $this->searchField => null,
+                $this->sortByField => $this->sortBy,
                 $this->sortDirField => $this->sortDir,
             ]);
         }

--- a/src/Traits/TableTemplatesCustomizations.php
+++ b/src/Traits/TableTemplatesCustomizations.php
@@ -6,14 +6,27 @@ use Okipa\LaravelTable\Table;
 
 trait TableTemplatesCustomizations
 {
-    /** @property string $tableComponentPath */
-    public $tableComponentPath;
-    /** @property string $theadComponentPath */
-    public $theadComponentPath;
-    /** @property string $tbodyComponentPath */
-    public $tbodyComponentPath;
+    /** @property string $tableTemplatePath */
+    public $tableTemplatePath;
+
+    /** @property string $theadTemplatePath */
+    public $theadTemplatePath;
+
+    /** @property string $tbodyTemplatePath */
+    public $tbodyTemplatePath;
+
+    /** @property string $showTemplatePath */
+    public $showTemplatePath;
+
+    /** @property string $editTemplatePath */
+    public $editTemplatePath;
+
+    /** @property string $destroyTemplatePath */
+    public $destroyTemplatePath;
+
     /** @property string $resultsComponentPath */
     public $resultsComponentPath;
+
     /** @property string $tfootComponentPath */
     public $tfootComponentPath;
 
@@ -21,13 +34,13 @@ trait TableTemplatesCustomizations
      * Set a custom template path for the table component.
      * The default table template path is defined in the config('laravel-table.template.table') config value.
      *
-     * @param string $tableComponentPath
+     * @param string $tableTemplatePath
      *
      * @return \Okipa\LaravelTable\Table
      */
-    public function tableTemplate(string $tableComponentPath): Table
+    public function tableTemplate(string $tableTemplatePath): Table
     {
-        $this->tableComponentPath = $tableComponentPath;
+        $this->tableTemplatePath = $tableTemplatePath;
 
         /** @var Table $this */
         return $this;
@@ -37,13 +50,13 @@ trait TableTemplatesCustomizations
      * Set a custom template path for the thead component.
      * The default thead template path is defined in the config('laravel-table.template.thead') config value.
      *
-     * @param string $theadComponentPath
+     * @param string $theadTemplatePath
      *
      * @return \Okipa\LaravelTable\Table
      */
-    public function theadTemplate(string $theadComponentPath): Table
+    public function theadTemplate(string $theadTemplatePath): Table
     {
-        $this->theadComponentPath = $theadComponentPath;
+        $this->theadTemplatePath = $theadTemplatePath;
 
         /** @var Table $this */
         return $this;
@@ -53,13 +66,61 @@ trait TableTemplatesCustomizations
      * Set a custom template path for the tbody component.
      * The default tbody template path is defined in the config('laravel-table.template.tbody') config value.
      *
-     * @param string $tbodyComponentPath
+     * @param string $tbodyTemplatePath
      *
      * @return \Okipa\LaravelTable\Table
      */
-    public function tbodyTemplate(string $tbodyComponentPath): Table
+    public function tbodyTemplate(string $tbodyTemplatePath): Table
     {
-        $this->tbodyComponentPath = $tbodyComponentPath;
+        $this->tbodyTemplatePath = $tbodyTemplatePath;
+
+        /** @var Table $this */
+        return $this;
+    }
+
+    /**
+     * Set a custom template path for the show component.
+     * The default show template path is defined in the config('laravel-table.template.show') config value.
+     *
+     * @param string $showTemplatePath
+     *
+     * @return \Okipa\LaravelTable\Table
+     */
+    public function showTemplate(string $showTemplatePath): Table
+    {
+        $this->showTemplatePath = $showTemplatePath;
+
+        /** @var Table $this */
+        return $this;
+    }
+
+    /**
+     * Set a custom template path for the edit component.
+     * The default edit template path is defined in the config('laravel-table.template.edit') config value.
+     *
+     * @param string $editTemplatePath
+     *
+     * @return \Okipa\LaravelTable\Table
+     */
+    public function editTemplate(string $editTemplatePath): Table
+    {
+        $this->editTemplatePath = $editTemplatePath;
+
+        /** @var Table $this */
+        return $this;
+    }
+
+    /**
+     * Set a custom template path for the destroy component.
+     * The default destroy template path is defined in the config('laravel-table.template.destroy') config value.
+     *
+     * @param string $destroyTemplatePath
+     *
+     * @return \Okipa\LaravelTable\Table
+     */
+    public function destroyTemplate(string $destroyTemplatePath): Table
+    {
+        $this->destroyTemplatePath = $destroyTemplatePath;
 
         /** @var Table $this */
         return $this;
@@ -104,10 +165,13 @@ trait TableTemplatesCustomizations
      */
     protected function initializeDefaultComponents(): void
     {
-        $this->tableComponentPath = config('laravel-table.template.table');
-        $this->theadComponentPath = config('laravel-table.template.thead');
-        $this->tbodyComponentPath = config('laravel-table.template.tbody');
-        $this->resultsComponentPath = config('laravel-table.template.results');
-        $this->tfootComponentPath = config('laravel-table.template.tfoot');
+        $this->tableTemplatePath = config('laravel-table.template.table', 'bootstrap.table');
+        $this->theadTemplatePath = config('laravel-table.template.thead', 'bootstrap.thead');
+        $this->tbodyTemplatePath = config('laravel-table.template.tbody', 'bootstrap.tbody');
+        $this->showTemplatePath = config('laravel-table.template.show', 'bootstrap.show');
+        $this->editTemplatePath = config('laravel-table.template.edit', 'bootstrap.edit');
+        $this->destroyTemplatePath = config('laravel-table.template.destroy', 'bootstrap.destroy');
+        $this->resultsComponentPath = config('laravel-table.template.results', 'bootstrap.results');
+        $this->tfootComponentPath = config('laravel-table.template.tfoot', 'bootstrap.tfoot');
     }
 }

--- a/tests/Fakers/CompaniesFaker.php
+++ b/tests/Fakers/CompaniesFaker.php
@@ -30,7 +30,7 @@ trait CompaniesFaker
         $max = User::all()->count();
 
         return [
-            'name'     => $this->faker->company,
+            'name' => $this->faker->company,
             'owner_id' => rand(1, $max),
             'turnover' => rand(1000, 99999),
         ];

--- a/tests/Fakers/UsersFaker.php
+++ b/tests/Fakers/UsersFaker.php
@@ -2,7 +2,7 @@
 
 namespace Okipa\LaravelTable\Test\Fakers;
 
-use Hash;
+use Illuminate\Support\Facades\Hash;
 use Okipa\LaravelTable\Test\Models\User;
 
 trait UsersFaker

--- a/tests/Fakers/UsersFaker.php
+++ b/tests/Fakers/UsersFaker.php
@@ -31,8 +31,8 @@ trait UsersFaker
         $this->clearPassword = $this->faker->word;
 
         return [
-            'name'     => $this->faker->word(10),
-            'email'    => $this->faker->email,
+            'name'     => $this->faker->unique()->name(),
+            'email'    => $this->faker->unique()->email,
             'password' => Hash::make($this->clearPassword),
         ];
     }

--- a/tests/Unit/AppendsTest.php
+++ b/tests/Unit/AppendsTest.php
@@ -50,7 +50,7 @@ class AppendsTest extends LaravelTableTestCase
             ->appends($appended);
         $table->column('name')->sortable()->searchable();
         $table->render();
-        $html = view('laravel-table::' . $table->theadComponentPath, compact('table'))->render();
+        $html = view('laravel-table::' . $table->theadTemplatePath, compact('table'))->render();
         $sortingHttpArguments = htmlspecialchars(http_build_query(array_merge([
             $table->rowsField    => 20,
             $table->searchField  => 'test',

--- a/tests/Unit/ButtonTest.php
+++ b/tests/Unit/ButtonTest.php
@@ -23,7 +23,7 @@ class ButtonTest extends LaravelTableTestCase
         $table = (new Table)->model(User::class)->routes(['index' => ['name' => 'users.index']]);
         $table->column('name')->button(['btn', 'btn-primary']);
         $table->render();
-        $html = view('laravel-table::' . $table->tbodyComponentPath, compact('table'))->render();
+        $html = view('laravel-table::' . $table->tbodyTemplatePath, compact('table'))->render();
         $this->assertStringContainsString('<button class="btn btn-primary', $html);
         $this->assertStringContainsString('</button>', $html);
     }
@@ -36,7 +36,7 @@ class ButtonTest extends LaravelTableTestCase
         $table = (new Table)->model(User::class)->routes(['index' => ['name' => 'users.index']]);
         $table->column('name')->button(['btn', 'btn-primary']);
         $table->render();
-        $html = view('laravel-table::' . $table->tbodyComponentPath, compact('table'))->render();
+        $html = view('laravel-table::' . $table->tbodyTemplatePath, compact('table'))->render();
         $this->assertStringNotContainsString('<button class="btn btn-primary', $html);
         $this->assertStringNotContainsString('</button>', $html);
     }
@@ -49,7 +49,7 @@ class ButtonTest extends LaravelTableTestCase
         $table = (new Table)->model(User::class)->routes(['index' => ['name' => 'users.index']]);
         $table->column('name')->button(['btn', 'btn-primary'])->icon('icon', true);
         $table->render();
-        $html = view('laravel-table::' . $table->tbodyComponentPath, compact('table'))->render();
+        $html = view('laravel-table::' . $table->tbodyTemplatePath, compact('table'))->render();
         $this->assertStringContainsString('<button class="btn btn-primary', $html);
         $this->assertStringContainsString('</button>', $html);
     }
@@ -64,7 +64,7 @@ class ButtonTest extends LaravelTableTestCase
             return 'user name = ' . $model->name;
         });
         $table->render();
-        $html = view('laravel-table::' . $table->tbodyComponentPath, compact('table'))->render();
+        $html = view('laravel-table::' . $table->tbodyTemplatePath, compact('table'))->render();
         $this->assertStringContainsString(
             '<button class="buttonClass user-name-' . Str::slug(strip_tags($user->name)) . '">',
             $html

--- a/tests/Unit/ClassesCustomizationsTest.php
+++ b/tests/Unit/ClassesCustomizationsTest.php
@@ -39,7 +39,7 @@ class ClassesDefinitionTest extends LaravelTableTestCase
         $table->column();
         $this->assertEquals($classes, $table->thClasses);
     }
-    
+
     public function testTdClassesAttribute()
     {
         $classes = ['test-custom-class'];
@@ -85,7 +85,7 @@ class ClassesDefinitionTest extends LaravelTableTestCase
             ->containerClasses($classes);
         $table->column('name');
         $table->render();
-        $html = view('laravel-table::' . $table->tableComponentPath, compact('table'))->render();
+        $html = view('laravel-table::' . $table->tableTemplatePath, compact('table'))->render();
         $this->assertStringContainsString('<div class="table-container ' . implode(' ', $classes) . '">', $html);
     }
 
@@ -99,7 +99,7 @@ class ClassesDefinitionTest extends LaravelTableTestCase
             ->tableClasses($classes);
         $table->column('name');
         $table->render();
-        $html = view('laravel-table::' . $table->tableComponentPath, compact('table'))->render();
+        $html = view('laravel-table::' . $table->tableTemplatePath, compact('table'))->render();
 
         $this->assertStringContainsString('<table class="table ' . implode(' ', $classes) . '">', $html);
     }
@@ -114,7 +114,7 @@ class ClassesDefinitionTest extends LaravelTableTestCase
             ->trClasses($classes);
         $table->column('name');
         $table->render();
-        $html = view('laravel-table::' . $table->tableComponentPath, compact('table'))->render();
+        $html = view('laravel-table::' . $table->tableTemplatePath, compact('table'))->render();
         $this->assertEquals(substr_count($html, '<tr '), substr_count($html, implode(' ', $classes)));
     }
 
@@ -128,7 +128,7 @@ class ClassesDefinitionTest extends LaravelTableTestCase
             ->thClasses($classes);
         $table->column('name');
         $table->render();
-        $html = view('laravel-table::' . $table->tableComponentPath, compact('table'))->render();
+        $html = view('laravel-table::' . $table->tableTemplatePath, compact('table'))->render();
         $this->assertEquals(substr_count($html, '<th '), substr_count($html, implode(' ', $classes)));
     }
 
@@ -142,7 +142,7 @@ class ClassesDefinitionTest extends LaravelTableTestCase
             ->tdClasses($classes);
         $table->column('name');
         $table->render();
-        $html = view('laravel-table::' . $table->tableComponentPath, compact('table'))->render();
+        $html = view('laravel-table::' . $table->tableTemplatePath, compact('table'))->render();
         $this->assertEquals(substr_count($html, '<td '), substr_count($html, implode(' ', $classes)));
     }
 
@@ -154,7 +154,7 @@ class ClassesDefinitionTest extends LaravelTableTestCase
         $table = (new Table)->model(User::class)->routes(['index' => ['name' => 'users.index']]);
         $table->column('name')->classes($classes);
         $table->render();
-        $html = view('laravel-table::' . $table->tbodyComponentPath, compact('table'))->render();
+        $html = view('laravel-table::' . $table->tbodyTemplatePath, compact('table'))->render();
         $this->assertEquals(2, substr_count($html, implode(' ', $classes)));
     }
 
@@ -168,7 +168,7 @@ class ClassesDefinitionTest extends LaravelTableTestCase
         $table->column('email');
         $table->result()->classes($classes);
         $table->render();
-        $html = view('laravel-table::' . $table->tbodyComponentPath, compact('table'))->render();
+        $html = view('laravel-table::' . $table->tbodyTemplatePath, compact('table'))->render();
         $this->assertEquals(1, substr_count($html, implode(' ', $classes)));
     }
 
@@ -194,7 +194,7 @@ class ClassesDefinitionTest extends LaravelTableTestCase
                 ? $this->assertEquals($user->conditionnalClasses, $classes)
                 : $this->assertEmpty($user->conditionnalClasses);
         }
-        $html = view('laravel-table::' . $table->tableComponentPath, compact('table'))->render();
+        $html = view('laravel-table::' . $table->tableTemplatePath, compact('table'))->render();
         $this->assertStringContainsString(implode(' ', $classes), $html);
         $this->assertEquals(2, substr_count($html, implode(' ', $classes)));
     }

--- a/tests/Unit/ConfigTest.php
+++ b/tests/Unit/ConfigTest.php
@@ -66,7 +66,7 @@ class ConfigTest extends LaravelTableTestCase
             ->searchable()
             ->sortable();
         $table->render();
-        $html = view('laravel-table::' . $table->tableComponentPath, compact('table'))->render();
+        $html = view('laravel-table::' . $table->tableTemplatePath, compact('table'))->render();
         $this->assertEquals(9999, $table->rows);
         $this->assertStringContainsString('value="9999"', $html);
         $this->assertStringContainsString('rows=9999', $html);

--- a/tests/Unit/DateTimeTest.php
+++ b/tests/Unit/DateTimeTest.php
@@ -24,7 +24,7 @@ class DateTimeTest extends LaravelTableTestCase
         $table->column('name');
         $table->column('updated_at')->dateTimeFormat('d/m/Y');
         $table->render();
-        $html = view('laravel-table::' . $table->tbodyComponentPath, compact('table'))->render();
+        $html = view('laravel-table::' . $table->tbodyTemplatePath, compact('table'))->render();
         $this->assertStringContainsString(Carbon::parse($user->updated_at)->format('d/m/Y'), $html);
     }
 
@@ -43,7 +43,7 @@ class DateTimeTest extends LaravelTableTestCase
         $table->column('name');
         $table->column('updated_at')->dateTimeFormat('d/m');
         $table->render();
-        $html = view('laravel-table::' . $table->tbodyComponentPath, compact('table'))->render();
+        $html = view('laravel-table::' . $table->tbodyTemplatePath, compact('table'))->render();
         $this->assertStringContainsString(Carbon::parse($user->updated_at)->format('d/m'), $html);
     }
 
@@ -55,7 +55,7 @@ class DateTimeTest extends LaravelTableTestCase
         $table->column('name');
         $table->column('updated_at')->dateTimeFormat('H\h i\m\i\n');
         $table->render();
-        $html = view('laravel-table::' . $table->tbodyComponentPath, compact('table'))->render();
+        $html = view('laravel-table::' . $table->tbodyTemplatePath, compact('table'))->render();
         $this->assertStringContainsString(Carbon::parse($user->updated_at)->format('H\h i\m\i\n'), $html);
     }
 
@@ -67,7 +67,7 @@ class DateTimeTest extends LaravelTableTestCase
         $table->column('name');
         $table->column('updated_at')->dateTimeFormat('d/m/Y H:i');
         $table->render();
-        $html = view('laravel-table::' . $table->tbodyComponentPath, compact('table'))->render();
+        $html = view('laravel-table::' . $table->tbodyTemplatePath, compact('table'))->render();
         $this->assertStringContainsString(Carbon::parse($user->updated_at)->format('d/m/Y H:i'), $html);
     }
 }

--- a/tests/Unit/DestroyHtmlAttributesTest.php
+++ b/tests/Unit/DestroyHtmlAttributesTest.php
@@ -46,7 +46,7 @@ class DestroyHtmlAttributesTest extends LaravelTableTestCase
         $table->column('name');
         $table->column('email');
         $table->render();
-        $html = view('laravel-table::' . $table->tbodyComponentPath, compact('table'))->render();
+        $html = view('laravel-table::' . $table->tbodyTemplatePath, compact('table'))->render();
         $this->assertEquals(5, substr_count($html, 'data-confirm'));
         foreach ($table->list as $model) {
             $this->assertStringContainsString(__('Are you sure you want to delete the user :name ?', [

--- a/tests/Unit/EmptyStatusTest.php
+++ b/tests/Unit/EmptyStatusTest.php
@@ -14,7 +14,7 @@ class EmptyStatusTest extends LaravelTableTestCase
         $table = (new Table)->model(User::class)->routes(['index' => ['name' => 'users.index']]);
         $table->column('name');
         $table->render();
-        $html = view('laravel-table::' . $table->tbodyComponentPath, compact('table'))->render();
+        $html = view('laravel-table::' . $table->tbodyTemplatePath, compact('table'))->render();
         $this->assertStringContainsString(config('laravel-table.icon.info'), $html);
         $this->assertStringContainsString(__('laravel-table::laravel-table.emptyTable'), $html);
     }
@@ -27,7 +27,7 @@ class EmptyStatusTest extends LaravelTableTestCase
         $table->column('name');
         $table->column('email');
         $table->render();
-        $html = view('laravel-table::' . $table->tbodyComponentPath, compact('table'))->render();
+        $html = view('laravel-table::' . $table->tbodyTemplatePath, compact('table'))->render();
         $this->assertStringNotContainsString(config('laravel-table.icon.info'), $html);
         $this->assertStringNotContainsString(__('laravel-table::laravel-table.emptyTable'), $html);
     }

--- a/tests/Unit/IconTest.php
+++ b/tests/Unit/IconTest.php
@@ -31,7 +31,7 @@ class IconTest extends LaravelTableTestCase
         $table = (new Table)->model(User::class)->routes(['index' => ['name' => 'users.index']]);
         $table->column('name')->icon('icon');
         $table->render();
-        $html = view('laravel-table::' . $table->tbodyComponentPath, compact('table'))->render();
+        $html = view('laravel-table::' . $table->tbodyTemplatePath, compact('table'))->render();
         $this->assertStringContainsString('icon', $html);
     }
 
@@ -44,7 +44,7 @@ class IconTest extends LaravelTableTestCase
             return 'test';
         });
         $table->render();
-        $html = view('laravel-table::' . $table->tbodyComponentPath, compact('table'))->render();
+        $html = view('laravel-table::' . $table->tbodyTemplatePath, compact('table'))->render();
         $this->assertStringContainsString('icon', $html);
     }
 
@@ -56,7 +56,7 @@ class IconTest extends LaravelTableTestCase
         $table = (new Table)->model(User::class)->routes(['index' => ['name' => 'users.index']]);
         $table->column('name')->icon('icon');
         $table->render();
-        $html = view('laravel-table::' . $table->tbodyComponentPath, compact('table'))->render();
+        $html = view('laravel-table::' . $table->tbodyTemplatePath, compact('table'))->render();
         $this->assertStringNotContainsString('icon', $html);
     }
 
@@ -68,7 +68,7 @@ class IconTest extends LaravelTableTestCase
         $table = (new Table)->model(User::class)->routes(['index' => ['name' => 'users.index']]);
         $table->column('name')->icon('icon', true);
         $table->render();
-        $html = view('laravel-table::' . $table->tbodyComponentPath, compact('table'))->render();
+        $html = view('laravel-table::' . $table->tbodyTemplatePath, compact('table'))->render();
         $this->assertStringContainsString('icon', $html);
     }
 }

--- a/tests/Unit/IdentifierTest.php
+++ b/tests/Unit/IdentifierTest.php
@@ -54,7 +54,7 @@ class IdentifierTest extends LaravelTableTestCase
             ->routes(['index' => ['name' => 'users.index']]);
         $table->column('name')->sortable()->searchable();
         $table->render();
-        $html = view('laravel-table::' . $table->tableComponentPath, compact('table'))->render();
+        $html = view('laravel-table::' . $table->tableTemplatePath, compact('table'))->render();
         $this->assertEquals(1, substr_count($html, '<table id="identifier-test"'));
     }
 
@@ -68,7 +68,7 @@ class IdentifierTest extends LaravelTableTestCase
             ->routes(['index' => ['name' => 'users.index']]);
         $table->column('name')->sortable()->searchable();
         $table->render();
-        $html = view('laravel-table::' . $table->theadComponentPath, compact('table'))->render();
+        $html = view('laravel-table::' . $table->theadTemplatePath, compact('table'))->render();
         $this->assertEquals(2, substr_count($html, 'name="identifier_test_rows"'));
     }
 
@@ -82,7 +82,7 @@ class IdentifierTest extends LaravelTableTestCase
             ->routes(['index' => ['name' => 'users.index']]);
         $table->column('name')->sortable()->searchable();
         $table->render();
-        $html = view('laravel-table::' . $table->theadComponentPath, compact('table'))->render();
+        $html = view('laravel-table::' . $table->theadTemplatePath, compact('table'))->render();
         $this->assertEquals(2, substr_count($html, 'name="identifier_test_search"'));
     }
 
@@ -96,7 +96,7 @@ class IdentifierTest extends LaravelTableTestCase
             ->routes(['index' => ['name' => 'users.index']]);
         $table->column('name')->sortable()->searchable();
         $table->render();
-        $html = view('laravel-table::' . $table->theadComponentPath, compact('table'))->render();
+        $html = view('laravel-table::' . $table->theadTemplatePath, compact('table'))->render();
         $this->assertEquals(2, substr_count($html, 'name="identifier_test_sort_by"'));
     }
 
@@ -110,7 +110,7 @@ class IdentifierTest extends LaravelTableTestCase
             ->routes(['index' => ['name' => 'users.index']]);
         $table->column('name')->sortable()->searchable();
         $table->render();
-        $html = view('laravel-table::' . $table->theadComponentPath, compact('table'))->render();
+        $html = view('laravel-table::' . $table->theadTemplatePath, compact('table'))->render();
         $this->assertEquals(2, substr_count($html, 'name="identifier_test_sort_dir"'));
     }
 }

--- a/tests/Unit/LinkTest.php
+++ b/tests/Unit/LinkTest.php
@@ -38,7 +38,7 @@ class LinkTest extends LaravelTableTestCase
         $table = (new Table)->model(User::class)->routes(['index' => ['name' => 'users.index']]);
         $table->column('name')->link();
         $table->render();
-        $html = view('laravel-table::' . $table->tbodyComponentPath, compact('table'))->render();
+        $html = view('laravel-table::' . $table->tbodyTemplatePath, compact('table'))->render();
         $this->assertStringContainsString('<a href="' . $user->name . '" title="' . $user->name . '">', $html);
     }
 
@@ -49,7 +49,7 @@ class LinkTest extends LaravelTableTestCase
         $table = (new Table)->model(User::class)->routes(['index' => ['name' => 'users.index']]);
         $table->column('name')->link('test');
         $table->render();
-        $html = view('laravel-table::' . $table->tbodyComponentPath, compact('table'))->render();
+        $html = view('laravel-table::' . $table->tbodyTemplatePath, compact('table'))->render();
         $this->assertStringContainsString('<a href="test" title="' . $user->name . '">', $html);
     }
 
@@ -62,7 +62,7 @@ class LinkTest extends LaravelTableTestCase
             return 'url';
         });
         $table->render();
-        $html = view('laravel-table::' . $table->tbodyComponentPath, compact('table'))->render();
+        $html = view('laravel-table::' . $table->tbodyTemplatePath, compact('table'))->render();
         $this->assertStringContainsString('<a href="url" title="' . $user->name . '">', $html);
     }
 
@@ -73,7 +73,7 @@ class LinkTest extends LaravelTableTestCase
         $table = (new Table)->model(User::class)->routes(['index' => ['name' => 'users.index']]);
         $table->column('name')->link();
         $table->render();
-        $html = view('laravel-table::' . $table->tbodyComponentPath, compact('table'))->render();
+        $html = view('laravel-table::' . $table->tbodyTemplatePath, compact('table'))->render();
         $this->assertStringContainsString('<a href="' . $user->name . '" title="' . $user->name . '">', $html);
     }
 
@@ -85,7 +85,7 @@ class LinkTest extends LaravelTableTestCase
         $table = (new Table)->model(User::class)->routes(['index' => ['name' => 'users.index']]);
         $table->column('name')->link();
         $table->render();
-        $html = view('laravel-table::' . $table->tbodyComponentPath, compact('table'))->render();
+        $html = view('laravel-table::' . $table->tbodyTemplatePath, compact('table'))->render();
         $this->assertStringNotContainsString('<a href="', $html);
     }
 
@@ -97,7 +97,7 @@ class LinkTest extends LaravelTableTestCase
         $table = (new Table)->model(User::class)->routes(['index' => ['name' => 'users.index']]);
         $table->column('name')->link()->icon('icon', true);
         $table->render();
-        $html = view('laravel-table::' . $table->tbodyComponentPath, compact('table'))->render();
+        $html = view('laravel-table::' . $table->tbodyTemplatePath, compact('table'))->render();
         $this->assertStringNotContainsString('<a href="', $html);
     }
 
@@ -111,7 +111,7 @@ class LinkTest extends LaravelTableTestCase
             return 'test';
         });
         $table->render();
-        $html = view('laravel-table::' . $table->tbodyComponentPath, compact('table'))->render();
+        $html = view('laravel-table::' . $table->tbodyTemplatePath, compact('table'))->render();
         $this->assertStringContainsString('<a href="url" title="test">', $html);
     }
 
@@ -125,7 +125,7 @@ class LinkTest extends LaravelTableTestCase
             return 'test';
         });
         $table->render();
-        $html = view('laravel-table::' . $table->tbodyComponentPath, compact('table'))->render();
+        $html = view('laravel-table::' . $table->tbodyTemplatePath, compact('table'))->render();
         $this->assertStringContainsString('<a href="test" title="test">', $html);
     }
 }

--- a/tests/Unit/ResultDeclarationTest.php
+++ b/tests/Unit/ResultDeclarationTest.php
@@ -30,7 +30,7 @@ class ResultDeclarationTest extends LaravelTableTestCase
             return $displayedList->sum('turnover');
         });
         $table->render();
-        $html = view('laravel-table::' . $table->tbodyComponentPath, compact('table'))->render();
+        $html = view('laravel-table::' . $table->tbodyTemplatePath, compact('table'))->render();
         $this->assertStringContainsString('Result !', $html);
         $this->assertStringContainsString((string) $companies->sum('turnover'), $html);
     }
@@ -52,7 +52,7 @@ class ResultDeclarationTest extends LaravelTableTestCase
             return (new Company)->all()->sum('turnover');
         });
         $table->render();
-        $html = view('laravel-table::' . $table->tbodyComponentPath, compact('table'))->render();
+        $html = view('laravel-table::' . $table->tbodyTemplatePath, compact('table'))->render();
         $this->assertStringContainsString('Selected turnover', $html);
         $this->assertStringContainsString((string) $companies->sum('turnover'), $html);
         $this->assertStringContainsString('Total turnover', $html);
@@ -69,7 +69,7 @@ class ResultDeclarationTest extends LaravelTableTestCase
         $table->column('name');
         $table->column('turnover');
         $table->render();
-        $html = view('laravel-table::' . $table->tbodyComponentPath, compact('table'))->render();
+        $html = view('laravel-table::' . $table->tbodyTemplatePath, compact('table'))->render();
         $this->assertStringNotContainsString('result', $html);
     }
 

--- a/tests/Unit/RoutesTest.php
+++ b/tests/Unit/RoutesTest.php
@@ -144,7 +144,7 @@ class RoutesTest extends LaravelTableTestCase
         ])->model(User::class);
         $table->column('name')->title('Name');
         $table->render();
-        $html = view('laravel-table::' . $table->tbodyComponentPath, compact('table'))->render();
+        $html = view('laravel-table::' . $table->tbodyTemplatePath, compact('table'))->render();
         foreach ($users as $user) {
             $this->assertStringContainsString('edit-' . $user->id, $html);
             $this->assertStringContainsString('action="http://localhost/users/edit?' . $user->id . '"', $html);
@@ -158,7 +158,7 @@ class RoutesTest extends LaravelTableTestCase
         $table = (new Table)->routes(['index' => ['name' => 'users.index']])->model(User::class);
         $table->column('name')->title('Name');
         $table->render();
-        $html = view('laravel-table::' . $table->tbodyComponentPath, compact('table'))->render();
+        $html = view('laravel-table::' . $table->tbodyTemplatePath, compact('table'))->render();
         foreach ($users as $user) {
             $this->assertStringNotContainsString('<form class="edit-' . $user->id, $html);
             $this->assertStringNotContainsString('action="http://localhost/users/edit?' . $user->id . '"', $html);
@@ -175,7 +175,7 @@ class RoutesTest extends LaravelTableTestCase
         ])->model(User::class);
         $table->column('name')->title('Name');
         $table->render();
-        $html = view('laravel-table::' . $table->tbodyComponentPath, compact('table'))->render();
+        $html = view('laravel-table::' . $table->tbodyTemplatePath, compact('table'))->render();
         foreach ($users as $user) {
             $this->assertStringContainsString('destroy-' . $user->id, $html);
             $this->assertStringContainsString('action="http://localhost/users/destroy?' . $user->id . '"', $html);
@@ -189,7 +189,7 @@ class RoutesTest extends LaravelTableTestCase
         $table = (new Table)->routes(['index' => ['name' => 'users.index']])->model(User::class);
         $table->column('name')->title('Name');
         $table->render();
-        $html = view('laravel-table::' . $table->tbodyComponentPath, compact('table'))->render();
+        $html = view('laravel-table::' . $table->tbodyTemplatePath, compact('table'))->render();
         foreach ($users as $user) {
             $this->assertStringNotContainsString('<form class="destroy-' . $user->id, $html);
             $this->assertStringNotContainsString('action="http://localhost/users/destroy?' . $user->id . '"', $html);
@@ -206,7 +206,7 @@ class RoutesTest extends LaravelTableTestCase
         ])->model(User::class);
         $table->column('name')->title('Name');
         $table->render();
-        $html = view('laravel-table::' . $table->tbodyComponentPath, compact('table'))->render();
+        $html = view('laravel-table::' . $table->tbodyTemplatePath, compact('table'))->render();
         foreach ($users as $user) {
             $this->assertStringContainsString('show-' . $user->id, $html);
             $this->assertStringContainsString('action="http://localhost/users/show?' . $user->id . '"', $html);
@@ -220,7 +220,7 @@ class RoutesTest extends LaravelTableTestCase
         $table = (new Table)->routes(['index' => ['name' => 'users.index']])->model(User::class);
         $table->column('name')->title('Name');
         $table->render();
-        $html = view('laravel-table::' . $table->tbodyComponentPath, compact('table'))->render();
+        $html = view('laravel-table::' . $table->tbodyTemplatePath, compact('table'))->render();
         foreach ($users as $user) {
             $this->assertStringNotContainsString('<form class="show-' . $user->id, $html);
             $this->assertStringNotContainsString('action="http://localhost/users/show?' . $user->id . '"', $html);
@@ -258,7 +258,7 @@ class RoutesTest extends LaravelTableTestCase
         ])->model(User::class);
         $table->column('name');
         $table->render();
-        $html = view('laravel-table::' . $table->tbodyComponentPath, compact('table'))->render();
+        $html = view('laravel-table::' . $table->tbodyTemplatePath, compact('table'))->render();
         $this->assertStringContainsString('action="http://localhost/user/edit/' . $user->id . '"', $html);
         $this->assertStringContainsString('action="http://localhost/user/destroy/' . $user->id . '"', $html);
         $this->assertStringContainsString('action="http://localhost/user/show/' . $user->id . '"', $html);
@@ -295,7 +295,7 @@ class RoutesTest extends LaravelTableTestCase
         ])->model(User::class);
         $table->column('name');
         $table->render();
-        $html = view('laravel-table::' . $table->tbodyComponentPath, compact('table'))->render();
+        $html = view('laravel-table::' . $table->tbodyTemplatePath, compact('table'))->render();
         $this->assertStringContainsString('action="http://localhost/user/edit/' . $user->id . '"', $html);
         $this->assertStringContainsString('action="http://localhost/user/destroy/' . $user->id . '"', $html);
         $this->assertStringContainsString('action="http://localhost/user/show/' . $user->id . '"', $html);
@@ -332,7 +332,7 @@ class RoutesTest extends LaravelTableTestCase
         ])->model(User::class);
         $table->column('name');
         $table->render();
-        $html = view('laravel-table::' . $table->tbodyComponentPath, compact('table'))->render();
+        $html = view('laravel-table::' . $table->tbodyTemplatePath, compact('table'))->render();
         $this->assertStringContainsString(
             'action="http://localhost/parent/11/user/edit/' . $user->id . '/child/33"',
             $html
@@ -378,7 +378,7 @@ class RoutesTest extends LaravelTableTestCase
         ])->model(User::class);
         $table->column('name');
         $table->render();
-        $html = view('laravel-table::' . $table->tbodyComponentPath, compact('table'))->render();
+        $html = view('laravel-table::' . $table->tbodyTemplatePath, compact('table'))->render();
         $this->assertStringContainsString(
             'action="http://localhost/parent/11/user/edit/' . $user->id . '/child/33"',
             $html

--- a/tests/Unit/RowDisableTest.php
+++ b/tests/Unit/RowDisableTest.php
@@ -44,7 +44,7 @@ class RowDisableTest extends LaravelTableTestCase
                 ? $this->assertEquals($user->disabledClasses, $classes)
                 : $this->assertEmpty($user->disabledClasses);
         }
-        $html = view('laravel-table::' . $table->tbodyComponentPath, compact('table'))->render();
+        $html = view('laravel-table::' . $table->tbodyTemplatePath, compact('table'))->render();
         $this->assertStringContainsString(implode(' ', $classes), $html);
         foreach ($users as $user) {
             if ($user->id === 1 || $user->id === 2) {
@@ -87,7 +87,7 @@ class RowDisableTest extends LaravelTableTestCase
                 ? $this->assertEquals($user->disabledClasses, $classes)
                 : $this->assertEmpty($user->disabledClasses);
         }
-        $html = view('laravel-table::' . $table->tbodyComponentPath, compact('table'))->render();
+        $html = view('laravel-table::' . $table->tbodyTemplatePath, compact('table'))->render();
         $this->assertStringContainsString(implode(' ', $classes), $html);
         foreach ($users as $user) {
             if ($user->id === 1 || $user->id === 2) {
@@ -119,7 +119,7 @@ class RowDisableTest extends LaravelTableTestCase
         $table->column('name')->title('Name');
         $table->column('email')->title('Email');
         $table->render();
-        $html = view('laravel-table::' . $table->tbodyComponentPath, compact('table'))->render();
+        $html = view('laravel-table::' . $table->tbodyTemplatePath, compact('table'))->render();
         $this->assertStringNotContainsString(implode(' ', $classes), $html);
         $this->assertStringNotContainsString('disabled="disabled"', $html);
     }

--- a/tests/Unit/RowsNumberTest.php
+++ b/tests/Unit/RowsNumberTest.php
@@ -37,7 +37,7 @@ class RowsNumberTest extends LaravelTableTestCase
         $table->column('name')->searchable();
         $table->column('email');
         $table->render();
-        $html = view('laravel-table::' . $table->theadComponentPath, compact('table'))->render();
+        $html = view('laravel-table::' . $table->theadTemplatePath, compact('table'))->render();
         $this->assertStringNotContainsString('rows-number-selection', $html);
         $this->assertStringNotContainsString('type="hidden" name="search"', $html);
         $this->assertStringNotContainsString(
@@ -60,7 +60,7 @@ class RowsNumberTest extends LaravelTableTestCase
         $table->column('name')->searchable();
         $table->column('email');
         $table->render();
-        $html = view('laravel-table::' . $table->theadComponentPath, compact('table'))->render();
+        $html = view('laravel-table::' . $table->theadTemplatePath, compact('table'))->render();
         $this->assertStringNotContainsString('rows-number-selection', $html);
         $this->assertStringNotContainsString('type="hidden" name="search"', $html);
         $this->assertStringNotContainsString(
@@ -83,7 +83,7 @@ class RowsNumberTest extends LaravelTableTestCase
         $table->column('name');
         $table->column('email');
         $table->render();
-        $html = view('laravel-table::' . $table->theadComponentPath, compact('table'))->render();
+        $html = view('laravel-table::' . $table->theadTemplatePath, compact('table'))->render();
         $this->assertStringContainsString('rows-number-selection', $html);
         $this->assertStringContainsString('type="hidden" name="search"', $html);
         $this->assertStringContainsString(
@@ -104,7 +104,7 @@ class RowsNumberTest extends LaravelTableTestCase
         $table->column('name');
         $table->column('email');
         $table->render();
-        $html = view('laravel-table::' . $table->theadComponentPath, compact('table'))->render();
+        $html = view('laravel-table::' . $table->theadTemplatePath, compact('table'))->render();
         $this->assertStringContainsString('value="15"', $html);
     }
 
@@ -117,7 +117,7 @@ class RowsNumberTest extends LaravelTableTestCase
         $table->column('name');
         $table->column('email');
         $table->render();
-        $html = view('laravel-table::' . $table->theadComponentPath, compact('table'))->render();
+        $html = view('laravel-table::' . $table->theadTemplatePath, compact('table'))->render();
         $this->assertStringContainsString('value="15"', $html);
     }
 
@@ -149,7 +149,7 @@ class RowsNumberTest extends LaravelTableTestCase
         $table->column('name');
         $table->column('email');
         $table->render();
-        $html = view('laravel-table::' . $table->tableComponentPath, compact('table'))->render();
+        $html = view('laravel-table::' . $table->tableTemplatePath, compact('table'))->render();
         $this->assertStringContainsString('value=""', $html);
         foreach ($users as $user) {
             $this->assertStringContainsString($user->name, $html);

--- a/tests/Unit/SearchTest.php
+++ b/tests/Unit/SearchTest.php
@@ -203,7 +203,7 @@ class SearchTest extends LaravelTableTestCase
             ->request($customRequest);
         $table->column('owner')->searchable('users_test', ['name']);
         $table->render();
-        $html = view('laravel-table::' . $table->tbodyComponentPath, compact('table'))->render();
+        $html = view('laravel-table::' . $table->tbodyTemplatePath, compact('table'))->render();
         foreach ($companies as $company) {
             if ($company->owner->name === $searchedValue) {
                 $this->assertStringContainsString($company->owner->name, $html);
@@ -321,7 +321,7 @@ class SearchTest extends LaravelTableTestCase
         $table->column('name');
         $table->column('email')->searchable();
         $table->render();
-        $html = view('laravel-table::' . $table->theadComponentPath, compact('table'))->render();
+        $html = view('laravel-table::' . $table->theadTemplatePath, compact('table'))->render();
         $this->assertStringContainsString('searching', $html);
         $this->assertStringContainsString('type="hidden" name="rows"', $html);
         $this->assertStringContainsString(
@@ -343,7 +343,7 @@ class SearchTest extends LaravelTableTestCase
         $table->column('name');
         $table->column('email');
         $table->render();
-        $html = view('laravel-table::' . $table->theadComponentPath, compact('table'))->render();
+        $html = view('laravel-table::' . $table->theadTemplatePath, compact('table'))->render();
         $this->assertStringNotContainsString('searching', $html);
         $this->assertStringNotContainsString('type="hidden" name="rows"', $html);
         $this->assertStringNotContainsString(

--- a/tests/Unit/SortTest.php
+++ b/tests/Unit/SortTest.php
@@ -187,7 +187,7 @@ class SortTest extends LaravelTableTestCase
         $table->column('name')->title('Name')->sortable();
         $table->column('email')->title('Email');
         $table->render();
-        $html = view('laravel-table::' . $table->theadComponentPath, compact('table'))->render();
+        $html = view('laravel-table::' . $table->theadTemplatePath, compact('table'))->render();
         $this->assertStringContainsString(
             'href="http://localhost/users/index?' . $table->rowsField . '=20&amp;' . $table->sortByField . '=name&amp;'
             . $table->sortDirField . '=desc"',

--- a/tests/Unit/TemplatesCustomizationsTest.php
+++ b/tests/Unit/TemplatesCustomizationsTest.php
@@ -12,21 +12,42 @@ class TemplatesCustomizationTest extends LaravelTableTestCase
     {
         $templatePath = 'table-test';
         $table = (new Table)->model(User::class)->tableTemplate($templatePath);
-        $this->assertEquals($templatePath, $table->tableComponentPath);
+        $this->assertEquals($templatePath, $table->tableTemplatePath);
     }
 
     public function testSetTheadTemplateAttribute()
     {
         $templatePath = 'thead-test';
         $table = (new Table)->model(User::class)->theadTemplate($templatePath);
-        $this->assertEquals($templatePath, $table->theadComponentPath);
+        $this->assertEquals($templatePath, $table->theadTemplatePath);
     }
 
     public function testSetTbodyTemplateAttribute()
     {
         $templatePath = 'tbody-test';
         $table = (new Table)->model(User::class)->tbodyTemplate($templatePath);
-        $this->assertEquals($templatePath, $table->tbodyComponentPath);
+        $this->assertEquals($templatePath, $table->tbodyTemplatePath);
+    }
+
+    public function testSetShowTemplateAttribute()
+    {
+        $templatePath = 'show-test';
+        $table = (new Table)->model(User::class)->showTemplate($templatePath);
+        $this->assertEquals($templatePath, $table->showTemplatePath);
+    }
+
+    public function testSetEditTemplateAttribute()
+    {
+        $templatePath = 'edit-test';
+        $table = (new Table)->model(User::class)->editTemplate($templatePath);
+        $this->assertEquals($templatePath, $table->editTemplatePath);
+    }
+
+    public function testSetDestroyTemplateAttribute()
+    {
+        $templatePath = 'edit-test';
+        $table = (new Table)->model(User::class)->destroyTemplate($templatePath);
+        $this->assertEquals($templatePath, $table->destroyTemplatePath);
     }
 
     public function testSetResultsTemplateAttribute()
@@ -42,7 +63,7 @@ class TemplatesCustomizationTest extends LaravelTableTestCase
         $table = (new Table)->model(User::class)->tfootTemplate($templatePath);
         $this->assertEquals($templatePath, $table->tfootComponentPath);
     }
-    
+
     public function testSetTableTemplateHtml()
     {
         view()->addNamespace('laravel-table', 'tests/views');
@@ -53,7 +74,7 @@ class TemplatesCustomizationTest extends LaravelTableTestCase
             ->tableTemplate('table-test');
         $table->column('name');
         $table->render();
-        $html = view('laravel-table::' . $table->tableComponentPath, compact('table'))->render();
+        $html = view('laravel-table::' . $table->tableTemplatePath, compact('table'))->render();
         $this->assertStringContainsString('<table id="table-test">', $html);
     }
 
@@ -67,7 +88,7 @@ class TemplatesCustomizationTest extends LaravelTableTestCase
             ->theadTemplate('thead-test');
         $table->column('name');
         $table->render();
-        $html = view('laravel-table::' . $table->theadComponentPath, compact('table'))->render();
+        $html = view('laravel-table::' . $table->theadTemplatePath, compact('table'))->render();
         $this->assertStringContainsString('<thead id="thead-test">', $html);
     }
 
@@ -81,8 +102,50 @@ class TemplatesCustomizationTest extends LaravelTableTestCase
             ->tbodyTemplate('tbody-test');
         $table->column('name');
         $table->render();
-        $html = view('laravel-table::' . $table->tbodyComponentPath, compact('table'))->render();
+        $html = view('laravel-table::' . $table->tbodyTemplatePath, compact('table'))->render();
         $this->assertStringContainsString('<tbody id="tbody-test">', $html);
+    }
+
+    public function testSetShowTemplateHtml()
+    {
+        view()->addNamespace('laravel-table', 'tests/views');
+        $this->createMultipleUsers(2);
+        $this->routes(['users'], ['index']);
+        $table = (new Table)->model(User::class)
+            ->routes(['index' => ['name' => 'users.index']])
+            ->showTemplate('show-test');
+        $table->column('name');
+        $table->render();
+        $html = view('laravel-table::' . $table->showTemplatePath, compact('table'))->render();
+        $this->assertStringContainsString('<form id="show-test">', $html);
+    }
+
+    public function testSetEditTemplateHtml()
+    {
+        view()->addNamespace('laravel-table', 'tests/views');
+        $this->createMultipleUsers(2);
+        $this->routes(['users'], ['index']);
+        $table = (new Table)->model(User::class)
+            ->routes(['index' => ['name' => 'users.index']])
+            ->editTemplate('edit-test');
+        $table->column('name');
+        $table->render();
+        $html = view('laravel-table::' . $table->editTemplatePath, compact('table'))->render();
+        $this->assertStringContainsString('<form id="edit-test">', $html);
+    }
+
+    public function testSetDestroyTemplateHtml()
+    {
+        view()->addNamespace('laravel-table', 'tests/views');
+        $this->createMultipleUsers(2);
+        $this->routes(['users'], ['index']);
+        $table = (new Table)->model(User::class)
+            ->routes(['index' => ['name' => 'users.index']])
+            ->destroyTemplate('destroy-test');
+        $table->column('name');
+        $table->render();
+        $html = view('laravel-table::' . $table->destroyTemplatePath, compact('table'))->render();
+        $this->assertStringContainsString('<form id="destroy-test">', $html);
     }
 
     public function testSetResultsTemplateHtml()

--- a/tests/Unit/TitleTest.php
+++ b/tests/Unit/TitleTest.php
@@ -22,7 +22,7 @@ class TitleTest extends LaravelTableTestCase
         $table->column('name')->title('Name');
         $table->column('email')->title('Email');
         $table->render();
-        $html = view('laravel-table::' . $table->theadComponentPath, compact('table'))->render();
+        $html = view('laravel-table::' . $table->theadTemplatePath, compact('table'))->render();
         $this->assertStringContainsString('Name', $html);
         $this->assertStringContainsString('Email', $html);
     }

--- a/tests/Unit/ValueTest.php
+++ b/tests/Unit/ValueTest.php
@@ -27,7 +27,7 @@ class CustomValueTest extends LaravelTableTestCase
             return 'user name = ' . $model->name;
         });
         $table->render();
-        $html = view('laravel-table::' . $table->tbodyComponentPath, compact('table'))->render();
+        $html = view('laravel-table::' . $table->tbodyTemplatePath, compact('table'))->render();
         $this->assertStringContainsString('user name = ' . $user->name, $html);
     }
 }

--- a/tests/views/destroy-test.blade.php
+++ b/tests/views/destroy-test.blade.php
@@ -1,0 +1,3 @@
+<form id="destroy-test"></form>
+
+

--- a/tests/views/edit-test.blade.php
+++ b/tests/views/edit-test.blade.php
@@ -1,0 +1,3 @@
+<form id="edit-test"></form>
+
+

--- a/tests/views/show-test.blade.php
+++ b/tests/views/show-test.blade.php
@@ -1,0 +1,3 @@
+<form id="show-test"></form>
+
+

--- a/tests/views/table-test.blade.php
+++ b/tests/views/table-test.blade.php
@@ -1,7 +1,7 @@
 <div>
     <table id="table-test">
-        @include('laravel-table::' . $table->theadComponentPath)
-        @include('laravel-table::' . $table->tbodyComponentPath)
+        @include('laravel-table::' . $table->theadTemplatePath)
+        @include('laravel-table::' . $table->tbodyTemplatePath)
         @include('laravel-table::' . $table->tfootComponentPath)
     </table>
 </div>

--- a/views/bootstrap/destroy.blade.php
+++ b/views/bootstrap/destroy.blade.php
@@ -1,0 +1,13 @@
+@if($table->isRouteDefined('destroy'))
+    <form id="destroy-{{ $model->getKey() }}"
+          class="ml-2 destroy"
+          role="form"
+          method="POST"
+          action="{{ $table->route('destroy', [$model]) }}">
+        @csrf()
+        @method('DELETE')
+        <button{{ classTag('btn', 'btn-link', 'p-0', 'text-danger', $model->disabledClasses ? 'disabled' : null) }} type="submit" title="@lang('laravel-table::laravel-table.destroy')"{{ htmlAttributes($model->destroyConfirmationAttributes, $model->disabledClasses ? ['disabled' => 'disabled'] : null) }}>
+            {!! config('laravel-table.icon.destroy') !!}
+        </button>
+    </form>
+@endif

--- a/views/bootstrap/edit.blade.php
+++ b/views/bootstrap/edit.blade.php
@@ -1,0 +1,11 @@
+@if($table->isRouteDefined('edit'))
+    <form id="edit-{{ $model->getKey() }}"
+          class="ml-2"
+          role="form"
+          method="GET"
+          action="{{ $table->route('edit', [$model]) }}">
+        <button{{ classTag('btn', 'btn-link', 'p-0', 'text-primary', $model->disabledClasses ? 'disabled' : null) }} type="submit" title="@lang('laravel-table::laravel-table.edit')"{{ htmlAttributes($model->disabledClasses ? ['disabled' => 'disabled'] : null) }}>
+            {!! config('laravel-table.icon.edit') !!}
+        </button>
+    </form>
+@endif

--- a/views/bootstrap/show.blade.php
+++ b/views/bootstrap/show.blade.php
@@ -1,0 +1,10 @@
+@if($table->isRouteDefined('show'))
+    <form id="show-{{ $model->getKey() }}"
+          role="form"
+          method="GET"
+          action="{{ $table->route('show', [$model]) }}">
+        <button{{ classTag('btn', 'btn-link', 'p-0', 'text-primary', $model->disabledClasses ? 'disabled' : null) }}type="submit" title="@lang('laravel-table::laravel-table.show')"{{ htmlAttributes($model->disabledClasses ? ['disabled' => 'disabled'] : null) }}>
+            {!! config('laravel-table.icon.show') !!}
+        </button>
+    </form>
+@endif

--- a/views/bootstrap/table.blade.php
+++ b/views/bootstrap/table.blade.php
@@ -1,7 +1,7 @@
 <div{{ classTag('table-container', $table->containerClasses) }}>
     <table{{ htmlAttributes($table->identifier ? ['id' => $table->identifier] : null) }}{{ classTag('table', $table->tableClasses) }}>
-        @include('laravel-table::' . $table->theadComponentPath)
-        @include('laravel-table::' . $table->tbodyComponentPath)
+        @include('laravel-table::' . $table->theadTemplatePath)
+        @include('laravel-table::' . $table->tbodyTemplatePath)
         @include('laravel-table::' . $table->tfootComponentPath)
     </table>
 </div>

--- a/views/bootstrap/tbody.blade.php
+++ b/views/bootstrap/tbody.blade.php
@@ -17,7 +17,7 @@
                         $customValue = $column->valueClosure ? ($column->valueClosure)($model, $column) : null;
                         $html = $column->htmlClosure ? ($column->htmlClosure)($model, $column) : null;
                         $link = $column->url instanceof Closure ? ($column->url)($model, $column) : ($column->url !== true
-                            ? $column->url 
+                            ? $column->url
                             : ($customValue ? $customValue : $value));
                         $showIcon = $column->icon && (($customValue || $value) || $column->displayIconWhenNoValue);
                         $showLink = $link && ($customValue || $value || $showIcon);
@@ -75,43 +75,9 @@
                     <td{{ classTag($table->tdClasses, 'text-right') }}>
                         @if(! $model->disabledClasses)
                             <div class="d-flex justify-content-end">
-                                {{-- show button --}}
-                                @if($table->isRouteDefined('show'))
-                                    <form id="show-{{ $model->getKey() }}"
-                                          role="form"
-                                          method="GET"
-                                          action="{{ $table->route('show', [$model]) }}">
-                                        <button{{ classTag('btn', 'btn-link', 'p-0', 'text-primary', $model->disabledClasses ? 'disabled' : null) }} type="submit" title="@lang('laravel-table::laravel-table.show')"{{ htmlAttributes($model->disabledClasses ? ['disabled' => 'disabled'] : null) }}>
-                                            {!! config('laravel-table.icon.show') !!}
-                                        </button>
-                                    </form>
-                                @endif
-                                {{-- edit button --}}
-                                @if($table->isRouteDefined('edit'))
-                                    <form id="edit-{{ $model->getKey() }}"
-                                          class="ml-2"
-                                          role="form"
-                                          method="GET"
-                                          action="{{ $table->route('edit', [$model]) }}">
-                                        <button{{ classTag('btn', 'btn-link', 'p-0', 'text-primary', $model->disabledClasses ? 'disabled' : null) }} type="submit" title="@lang('laravel-table::laravel-table.edit')"{{ htmlAttributes($model->disabledClasses ? ['disabled' => 'disabled'] : null) }}>
-                                            {!! config('laravel-table.icon.edit') !!}
-                                        </button>
-                                    </form>
-                                @endif
-                                {{-- destroy button --}}
-                                @if($table->isRouteDefined('destroy'))
-                                    <form id="destroy-{{ $model->getKey() }}"
-                                          class="ml-2 destroy"
-                                          role="form"
-                                          method="POST"
-                                          action="{{ $table->route('destroy', [$model]) }}">
-                                        @csrf()
-                                        @method('DELETE')
-                                        <button{{ classTag('btn', 'btn-link', 'p-0', 'text-danger', $model->disabledClasses ? 'disabled' : null) }} type="submit" title="@lang('laravel-table::laravel-table.destroy')"{{ htmlAttributes($model->destroyConfirmationAttributes, $model->disabledClasses ? ['disabled' => 'disabled'] : null) }}>
-                                            {!! config('laravel-table.icon.destroy') !!}
-                                        </button>
-                                    </form>
-                                @endif
+                                @include('laravel-table::' . $table->showTemplatePath)
+                                @include('laravel-table::' . $table->editTemplatePath)
+                                @include('laravel-table::' . $table->destroyTemplatePath)
                             </div>
                         @endif
                     </td>


### PR DESCRIPTION
* Added more granularity in the template customization possibilities : the `show`, `edit` and `destroy` actions are now defined in their own component. This way, it becomes easier to customize tiny parts of the table without touching to the others.
  * Added `config('laravel-table.template.show')`, `config('laravel-table.template.edit')` and `config('laravel-table.template.destroy')` configs to set each new default component path.
  * Added `->showTemplate()`, `->editTemplate()` and `->destroyTemplate()` to give the ability to customize these templates on the fly.
* Added fallback path for each template if the config value is not defined, in order to prevent any update breaking change.