### PR TITLE
3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [3.0.2](https://github.com/Okipa/laravel-table/compare/3.0.1...3.0.2)
+## [3.1.0](https://github.com/Okipa/laravel-table/compare/3.0.1...3.1.0)
 
 2020-08-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 * Reverted the previous change (3.0.1) as the `button` method without arguments has no visual effect: added instructions in the upgrade-guide to take care of this new behaviour.
 * Fixed create action button which was not displayed when searching and rows number definition were not activated.
-* Reverted a v3 regression 
+* Fixed a v3 regression where `rows number definition` was named `rows number selection` at different places (config, templates, methods, ...): this is an unfortunately breaking change if you published config or templates but I take advantage of the early release of the V3 and from the fact that Laravel 8 is not released to do it.
 * Minor default templates changes.
 * Minor default config value changes.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@
 
 2020-08-24
 
-* Reverted the previous change (3.0.1) as the `button` method without arguments has no visual effect: added instructions in the upgrade-guide to take care of this new behaviour.
-* Fixed create action button which was not displayed when searching and rows number definition were not activated.
-* Fixed a v3 regression where `rows number definition` was named `rows number selection` at different places (config, templates, methods, ...): this is an unfortunately breaking change if you published config or templates but I take advantage of the early release of the V3 and from the fact that Laravel 8 is not released to do it.
-* Minor default templates changes.
-* Minor default config value changes.
+* Reverted the previous change (3.0.1) as the `button` method without arguments has no visual effect: added instructions in V2 to v3 the upgrade-guide to take care of this new behaviour.
+* Fixed an issue where create action button was not displayed when searching and rows number definition were disabled.
+* Fixed a v3 regression where `rows number definition` was wrongly named `rows number selection` at different places (config, templates, methods, ...): this is an unfortunately breaking change if you published config or templates but I take advantage of the early release of the V3 and from the fact that Laravel 8 is not released to do it.
+* Minor default templates changes in order to give laravel-table a prettier look.
+* Minor default config value changes in order to give laravel-table a prettier look.
 
 ## [3.0.1](https://github.com/Okipa/laravel-table/compare/3.0.1...3.0.1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Reverted the previous change (3.0.1) as the `button` method without arguments has no visual effect: added instructions in V2 to v3 the upgrade-guide to take care of this new behaviour.
 * Fixed an issue where create action button was not displayed when searching and rows number definition were disabled.
 * Fixed a v3 regression where `rows number definition` was wrongly named `rows number selection` at different places (config, templates, methods, ...): this is an unfortunately breaking change if you published config or templates but I take advantage of the early release of the V3 and from the fact that Laravel 8 is not released to do it.
+* Show and edit actions are now triggered by a simple link rather than a form, which was useless as these routes are called with a `GET` http request.
 * Minor default templates changes in order to give laravel-table a prettier look.
 * Minor default config value changes in order to give laravel-table a prettier look.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Reverted the previous change (3.0.1) as the `button` method without arguments has no visual effect: added instructions in the upgrade-guide to take care of this new behaviour.
 * Fixed create action button which was not displayed when searching and rows number definition were not activated.
+* Reverted a v3 regression 
 * Minor default templates changes.
 * Minor default config value changes.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [3.0.2](https://github.com/Okipa/laravel-table/compare/3.0.1...3.0.2)
+
+2020-08-24
+
+* Reverted the previous change (3.0.1) as the `button` method without arguments has no visual effect: added instructions in the upgrade-guide to take care of this new behaviour.
+* Fixed create action button which was not displayed when searching and rows number definition were not activated.
+* Minor default templates changes.
+* Minor default config value changes.
+
 ## [3.0.1](https://github.com/Okipa/laravel-table/compare/3.0.1...3.0.1)
 
 2020-08-24
@@ -14,7 +23,7 @@
 * Dropped Laravel 6 support
 * Added template customization methods for `Table` instances :
   * `rowsSearchingTemplate`
-  * `rowsNumberSelectionTemplate`
+  * `rowsNumberDefinitionTemplate`
   * `createActionTemplate`
   * `columnTitlesTemplate`
   * `navigationStatusTemplate`

--- a/README.md
+++ b/README.md
@@ -492,9 +492,9 @@ class UsersTable extends AbstractTable
 
 <h3 id="table-activateRowsNumberDefinition">activateRowsNumberDefinition</h3>
 
-> Override the default rows number selection activation status.  
+> Override the default rows number definition activation status.  
 > Calling this method displays a rows number input that enable the user to choose how much rows to show.  
-> The default rows number selection activation status is managed by the `config('laravel-table.behavior.activate_rows_number_definition')` value.
+> The default rows number definition activation status is managed by the `config('laravel-table.behavior.activate_rows_number_definition')` value.
 
 **Note:**`
 
@@ -532,7 +532,7 @@ class UsersTable extends AbstractTable
 
 > Add an array of arguments that will be appended to the paginator and to the following table actions:
 >
-> * row number selection
+> * row number definition
 > * searching
 > * search cancelling
 > * sorting.
@@ -749,7 +749,7 @@ destroyButton.click((e) => {
 
 <h3 id="table-rowsNumberDefinitionTemplate">rowsNumberDefinitionTemplate</h3>
 
-> Set a custom view path for the rows number selection template.  
+> Set a custom view path for the rows number definition template.  
 > The default view path is defined in the `config('laravel-table.template.rows_number_definition')` config value.
 
 **Note:**

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Finally, display it in the view:
   * [tableTemplate](#table-tableTemplate)
   * [theadTemplate](#table-theadTemplate)
   * [rowsSearchingTemplate](#table-rowsSearchingTemplate)
-  * [rowsNumberSelectionTemplate](#table-rowsNumberSelectionTemplate)
+  * [rowsNumberDefinitionTemplate](#table-rowsNumberDefinitionTemplate)
   * [createActionTemplate](#table-createActionTemplate)
   * [columnTitlesTemplate](#table-columnTitlesTemplate)
   * [tbodyTemplate](#table-tbodyTemplate)
@@ -260,7 +260,7 @@ class NewsTable extends AbstractTable
             })
             ->disableRows(
                 fn(News $news) => in_array($news->id, [1, 2]),
-                ['disabled', 'bg-secondary']
+                ['disabled', 'bg-secondary', 'text-white']
             )
             ->rowsConditionalClasses(
                 fn(News $news) => $news->id === 3,
@@ -747,20 +747,20 @@ destroyButton.click((e) => {
 (new Table)->rowsSearchingTemplate('tailwindCss.rows-searching');
 ```
 
-<h3 id="table-rowsNumberSelectionTemplate">rowsNumberSelectionTemplate</h3>
+<h3 id="table-rowsNumberDefinitionTemplate">rowsNumberDefinitionTemplate</h3>
 
 > Set a custom view path for the rows number selection template.  
-> The default view path is defined in the `config('laravel-table.template.rows_number_selection')` config value.
+> The default view path is defined in the `config('laravel-table.template.rows_number_definition')` config value.
 
 **Note:**
 
-* Signature: `rowsNumberSelectionTemplate(string $rowsNumberSelectionTemplatePath): \Okipa\LaravelTable\Table`
+* Signature: `rowsNumberDefinitionTemplate(string $rowsNumberDefinitionTemplatePath): \Okipa\LaravelTable\Table`
 * Optional
 
 **Use case example:**
 
 ```php
-(new Table)->rowsSearchingTemplate('tailwindCss.rows-number-selection');
+(new Table)->rowsSearchingTemplate('tailwindCss.rows-number-definition');
 ```
 
 <h3 id="table-createActionTemplate">createActionTemplate</h3>

--- a/config/laravel-table.php
+++ b/config/laravel-table.php
@@ -5,11 +5,11 @@ return [
     /** Set the default classes for each part of the table. */
     'classes' => [
         'container' => ['table-responsive'],
-        'table' => ['table-striped', 'table-hover'],
-        'tr' => [],
+        'table' => ['table-borderless'],
+        'tr' => ['border-bottom'],
         'th' => ['align-middle'],
         'td' => ['align-middle'],
-        'results' => ['bg-light', 'font-weight-bold'],
+        'results' => ['table-secondary'],
         'disabled' => ['table-danger', 'disabled'],
     ],
 

--- a/config/laravel-table.php
+++ b/config/laravel-table.php
@@ -40,7 +40,7 @@ return [
         'table' => 'bootstrap.table',
         'thead' => 'bootstrap.thead',
         'rows_searching' => 'bootstrap.rows-searching',
-        'rows_number_selection' => 'bootstrap.rows-number-selection',
+        'rows_number_definition' => 'bootstrap.rows-number-definition',
         'create_action' => 'bootstrap.create-action',
         'column_titles' => 'bootstrap.column-titles',
         'tbody' => 'bootstrap.tbody',

--- a/docs/upgrade-guides/from-v2-to-v3.md
+++ b/docs/upgrade-guides/from-v2-to-v3.md
@@ -17,6 +17,7 @@ There are small changes in the API you will have to report in your code:
 * Search and replace each `Table` use of `->showTemplate(` by `->showActionTemplate(`.
 * Search and replace each `Table` use of `->editTemplate(` by `->editActionTemplate(`.
 * Search and replace each `Table` use of `->destroyTemplate(` by `->destroyActionTemplate(`.
+* The use of the `button` method on `Column` class should not be used without argument and will now trigger an error if no array is given.
 
 ## See all changes
 

--- a/resources/views/bootstrap/column-titles.blade.php
+++ b/resources/views/bootstrap/column-titles.blade.php
@@ -1,4 +1,4 @@
-<tr{{ classTag($table->getTrClasses()) }}>
+<tr{{ classTag('bg-light', $table->getTrClasses()) }}>
     @foreach($table->getColumns() as $column)
         <th{{ classTag($table->getThClasses()) }} scope="col">
         @if($column->getIsSortable())
@@ -23,14 +23,14 @@
                     {!! str_replace(' ', '&nbsp;', $column->getTitle()) !!}
                 </span>
             </a>
-            @else
-                {!! str_replace(' ', '&nbsp;', $column->getTitle()) !!}
-            @endif
-                </th>
-            @endforeach
-            @if($table->isRouteDefined('show') || $table->isRouteDefined('edit') || $table->isRouteDefined('destroy'))
-                <th{{ classTag('text-right', $table->getThClasses()) }} scope="col">
-                    @lang('Actions')
-                </th>
-            @endif
+        @else
+            {!! str_replace(' ', '&nbsp;', $column->getTitle()) !!}
+        @endif
+        </th>
+    @endforeach
+    @if($table->isRouteDefined('show') || $table->isRouteDefined('edit') || $table->isRouteDefined('destroy'))
+        <th{{ classTag('text-right', $table->getThClasses()) }} scope="col">
+            @lang('Actions')
+        </th>
+    @endif
 </tr>

--- a/resources/views/bootstrap/create-action.blade.php
+++ b/resources/views/bootstrap/create-action.blade.php
@@ -1,5 +1,5 @@
 @if($table->isRouteDefined('create'))
-    <div class="d-flex align-items-center px-3 py-1 create-action">
+    <div class="d-flex align-items-center pl-3 py-1 create-action">
         <a href="{{ $table->getRoute('create') }}"
            class="btn btn-success"
            title="@lang('Create')">

--- a/resources/views/bootstrap/edit-action.blade.php
+++ b/resources/views/bootstrap/edit-action.blade.php
@@ -1,11 +1,7 @@
 @if($table->isRouteDefined('edit'))
-    <form id="edit-{{ $model->getKey() }}"
-        class="ml-2 edit-action"
-        role="form"
-        method="GET"
-        action="{{ $table->getRoute('edit', [$model]) }}">
-        <button{{ classTag('btn', 'btn-link', 'p-0', 'text-primary', $model->disabled_classes ? 'disabled' : null) }} type="submit" title="@lang('Edit')"{{ htmlAttributes($model->disabled_classes ? ['disabled' => 'disabled'] : null) }}>
+    <div id="edit-{{ $model->getKey() }}" class="ml-2 edit-action">
+        <a{{ classTag('btn', 'btn-link', 'p-0', 'text-primary', $model->disabled_classes ? 'disabled' : null) }} href="{{ $table->getRoute('edit', [$model]) }}" title="@lang('Edit')"{{ htmlAttributes($model->disabled_classes ? ['disabled' => 'disabled'] : null) }}>
             {!! config('laravel-table.icon.edit') !!}
-        </button>
-    </form>
+        </a>
+    </div>
 @endif

--- a/resources/views/bootstrap/rows-number-definition.blade.php
+++ b/resources/views/bootstrap/rows-number-definition.blade.php
@@ -1,5 +1,5 @@
 @if($table->getRowsNumberDefinitionActivation())
-    <div class="px-3 py-1 rows-number-selection" style="width: 12rem;">
+    <div class="px-xl-3 py-1 rows-number-definition">
         <form role="form" method="GET" action="{{ $table->getRoute('index') }}">
             <input type="hidden" name="{{ $table->getSearchField() }}" value="{{ $table->getRequest()->get($table->getSearchField()) }}">
             <input type="hidden" name="{{ $table->getSortByField() }}" value="{{ $table->getRequest()->get($table->getSortByField()) }}">

--- a/resources/views/bootstrap/rows-searching.blade.php
+++ b/resources/views/bootstrap/rows-searching.blade.php
@@ -1,5 +1,5 @@
 @if($table->getSearchableColumns()->count())
-    <div class="flex-fill px-3 py-1 searching">
+    <div class="flex-fill pr-xl-3 py-1 searching">
         <form role="form" method="GET" action="{{ $table->getRoute('index') }}">
             <input type="hidden" name="{{ $table->getRowsNumberField() }}" value="{{ $table->getRequest()->get($table->getRowsNumberField()) }}">
             <input type="hidden" name="{{ $table->getSortByField() }}" value="{{ $table->getRequest()->get($table->getSortByField()) }}">
@@ -14,11 +14,11 @@
                     </span>
                 </div>
                 <input class="form-control"
-                   type="text"
-                   name="{{ $table->getSearchField() }}"
-                   value="{{ $table->getRequest()->get($table->getSearchField()) }}"
-                   placeholder="@lang('Search by:') {{ $table->getSearchableTitles() }}"
-                   aria-label="@lang('Search by:') {{ $table->getSearchableTitles() }}">
+                       type="text"
+                       name="{{ $table->getSearchField() }}"
+                       value="{{ $table->getRequest()->get($table->getSearchField()) }}"
+                       placeholder="@lang('Search by:') {{ $table->getSearchableTitles() }}"
+                       aria-label="@lang('Search by:') {{ $table->getSearchableTitles() }}">
                 @if($table->getRequest()->get($table->getSearchField()))
                     <div class="input-group-append">
                         <a class="input-group-text btn btn-link text-danger reset-research"

--- a/resources/views/bootstrap/show-action.blade.php
+++ b/resources/views/bootstrap/show-action.blade.php
@@ -1,11 +1,7 @@
 @if($table->isRouteDefined('show'))
-    <form id="show-{{ $model->getKey() }}"
-        class="show-action"
-        role="form"
-        method="GET"
-        action="{{ $table->getRoute('show', [$model]) }}">
-        <button{{ classTag('btn', 'btn-link', 'p-0', 'text-primary', $model->disabled_classes ? 'disabled' : null) }}type="submit" title="@lang('Show')"{{ htmlAttributes($model->disabled_classes ? ['disabled' => 'disabled'] : null) }}>
+    <div id="show-{{ $model->getKey() }}" class="show-action">
+        <a{{ classTag('btn', 'btn-link', 'p-0', 'text-primary', $model->disabled_classes ? 'disabled' : null) }} href="{{ $table->getRoute('show', [$model]) }}" title="@lang('Show')"{{ htmlAttributes($model->disabled_classes ? ['disabled' => 'disabled'] : null) }}>
             {!! config('laravel-table.icon.show') !!}
-        </button>
-    </form>
+        </a>
+    </div>
 @endif

--- a/resources/views/bootstrap/tfoot.blade.php
+++ b/resources/views/bootstrap/tfoot.blade.php
@@ -1,7 +1,7 @@
 <tfoot>
     <tr{{ classTag($table->getTrClasses()) }}>
         <td{{ classTag('bg-light', $table->getTdClasses()) }}{{ htmlAttributes($table->getColumnsCount() > 1 ? ['colspan' => $table->getColumnsCount()] : null) }}>
-            <div class="d-flex justify-content-between flex-wrap py-2">
+            <div class="d-flex justify-content-between flex-wrap">
                 @include('laravel-table::' . $table->getNavigationStatusTemplatePath())
                 @include('laravel-table::' . $table->getPaginationTemplatePath())
             </div>

--- a/resources/views/bootstrap/thead.blade.php
+++ b/resources/views/bootstrap/thead.blade.php
@@ -1,18 +1,20 @@
 <thead>
-    @if($table->getRowsNumberDefinitionActivation() || ! $table->getSearchableColumns()->isEmpty())
-        <tr{{ classTag($table->getTrClasses()) }}>
-            <td{{ classTag('bg-light', $table->getTdClasses()) }}{{ htmlAttributes($table->getColumnsCount() > 1 ? ['colspan' => $table->getColumnsCount()] : null) }}>
-                <div class="d-flex flex-column flex-xl-row py-2">
-                    <div class="flex-fill">
+    <tr{{ classTag('bg-white', $table->getTrClasses()) }}>
+        <td{{ classTag('px-0', $table->getTdClasses()) }}{{ htmlAttributes($table->getColumnsCount() > 1 ? ['colspan' => $table->getColumnsCount()] : null) }}>
+            <div class="d-flex flex-column flex-xl-row">
+                <div class="flex-fill">
+                    @if($table->getSearchableColumns()->isNotEmpty())
                         @include('laravel-table::' . $table->getRowsSearchingTemplatePath())
-                    </div>
-                    <div class="d-flex justify-content-between">
-                        @include('laravel-table::' . $table->getRowsNumberSelectionTemplatePath())
-                        @include('laravel-table::' . $table->getCreateActionTemplatePath())
-                    </div>
+                    @endif
                 </div>
-            </td>
-        </tr>
-    @endif
+                <div class="d-flex justify-content-between">
+                    @if($table->getRowsNumberDefinitionActivation())
+                        @include('laravel-table::' . $table->getrowsNumberDefinitionTemplatePath())
+                    @endif
+                    @include('laravel-table::' . $table->getCreateActionTemplatePath())
+                </div>
+            </div>
+        </td>
+    </tr>
     @include('laravel-table::' . $table->getColumnTitlesTemplatePath())
 </thead>

--- a/src/Traits/Column/IsButton.php
+++ b/src/Traits/Column/IsButton.php
@@ -8,7 +8,7 @@ trait IsButton
 {
     protected array $buttonClasses = [];
 
-    public function button(array $buttonClasses = []): Column
+    public function button(array $buttonClasses): Column
     {
         $this->buttonClasses = $buttonClasses;
 

--- a/src/Traits/Table/HasTemplates.php
+++ b/src/Traits/Table/HasTemplates.php
@@ -12,7 +12,7 @@ trait HasTemplates
 
     protected string $rowsSearchingTemplatePath;
 
-    protected string $rowsNumberSelectionTemplatePath;
+    protected string $rowsNumberDefinitionTemplatePath;
 
     protected string $createActionTemplatePath;
 
@@ -73,17 +73,17 @@ trait HasTemplates
         return $this->rowsSearchingTemplatePath;
     }
 
-    public function rowsNumberSelectionTemplate(string $rowsNumberSelectionTemplatePath): Table
+    public function rowsNumberDefinitionTemplate(string $rowsNumberDefinitionTemplatePath): Table
     {
-        $this->rowsNumberSelectionTemplatePath = $rowsNumberSelectionTemplatePath;
+        $this->rowsNumberDefinitionTemplatePath = $rowsNumberDefinitionTemplatePath;
 
         /** @var \Okipa\LaravelTable\Table $this */
         return $this;
     }
 
-    public function getRowsNumberSelectionTemplatePath(): string
+    public function getrowsNumberDefinitionTemplatePath(): string
     {
-        return $this->rowsNumberSelectionTemplatePath;
+        return $this->rowsNumberDefinitionTemplatePath;
     }
 
     public function createActionTemplate(string $createActionTemplatePath): Table
@@ -221,7 +221,7 @@ trait HasTemplates
         $this->tableTemplatePath = config('laravel-table.template.table');
         $this->theadTemplatePath = config('laravel-table.template.thead');
         $this->rowsSearchingTemplatePath = config('laravel-table.template.rows_searching');
-        $this->rowsNumberSelectionTemplatePath = config('laravel-table.template.rows_number_selection');
+        $this->rowsNumberDefinitionTemplatePath = config('laravel-table.template.rows_number_definition');
         $this->createActionTemplatePath = config('laravel-table.template.create_action');
         $this->columnTitlesTemplatePath = config('laravel-table.template.column_titles');
         $this->tbodyTemplatePath = config('laravel-table.template.tbody');

--- a/tests/Unit/ConfigTest.php
+++ b/tests/Unit/ConfigTest.php
@@ -42,7 +42,7 @@ class ConfigTest extends LaravelTableTestCase
         $this->assertTrue(array_key_exists('table', config('laravel-table.template')));
         $this->assertTrue(array_key_exists('thead', config('laravel-table.template')));
         $this->assertTrue(array_key_exists('rows_searching', config('laravel-table.template')));
-        $this->assertTrue(array_key_exists('rows_number_selection', config('laravel-table.template')));
+        $this->assertTrue(array_key_exists('rows_number_definition', config('laravel-table.template')));
         $this->assertTrue(array_key_exists('create_action', config('laravel-table.template')));
         $this->assertTrue(array_key_exists('column_titles', config('laravel-table.template')));
         $this->assertTrue(array_key_exists('tbody', config('laravel-table.template')));

--- a/tests/Unit/RoutesTest.php
+++ b/tests/Unit/RoutesTest.php
@@ -122,6 +122,21 @@ class RoutesTest extends LaravelTableTestCase
         $this->assertStringContainsString('title="Create"', $html);
     }
 
+    public function testSetCreateRouteWillShowCreateActionEventIfSearchingAndRowsNumberDefinitionAreDisabledHtml()
+    {
+        $this->routes(['users'], ['index', 'create']);
+        $table = (new Table)->routes([
+            'index' => ['name' => 'users.index'],
+            'create' => ['name' => 'users.create'],
+        ])->model(User::class)->activateRowsNumberDefinition(false);
+        $table->column('name')->title('Name');
+        $table->configure();
+        $html = view('laravel-table::' . $table->getTheadTemplatePath(), compact('table'))->toHtml();
+        $this->assertStringContainsString('create-action', $html);
+        $this->assertStringContainsString('href="http://localhost/users/create"', $html);
+        $this->assertStringContainsString('title="Create"', $html);
+    }
+
     public function testSetNoCreateRouteHtml()
     {
         $this->routes(['users'], ['index', 'create']);

--- a/tests/Unit/RoutesTest.php
+++ b/tests/Unit/RoutesTest.php
@@ -162,7 +162,7 @@ class RoutesTest extends LaravelTableTestCase
         $html = view('laravel-table::' . $table->getTbodyTemplatePath(), compact('table'))->toHtml();
         foreach ($users as $user) {
             $this->assertStringContainsString('edit-' . $user->id, $html);
-            $this->assertStringContainsString('action="http://localhost/users/edit?' . $user->id . '"', $html);
+            $this->assertStringContainsString('href="http://localhost/users/edit?' . $user->id . '"', $html);
         }
     }
 
@@ -176,7 +176,7 @@ class RoutesTest extends LaravelTableTestCase
         $html = view('laravel-table::' . $table->getTbodyTemplatePath(), compact('table'))->toHtml();
         foreach ($users as $user) {
             $this->assertStringNotContainsString('<form class="edit-' . $user->id, $html);
-            $this->assertStringNotContainsString('action="http://localhost/users/edit?' . $user->id . '"', $html);
+            $this->assertStringNotContainsString('href="http://localhost/users/edit?' . $user->id . '"', $html);
         }
     }
 
@@ -224,7 +224,7 @@ class RoutesTest extends LaravelTableTestCase
         $html = view('laravel-table::' . $table->getTbodyTemplatePath(), compact('table'))->toHtml();
         foreach ($users as $user) {
             $this->assertStringContainsString('show-' . $user->id, $html);
-            $this->assertStringContainsString('action="http://localhost/users/show?' . $user->id . '"', $html);
+            $this->assertStringContainsString('href="http://localhost/users/show?' . $user->id . '"', $html);
         }
     }
 
@@ -238,7 +238,7 @@ class RoutesTest extends LaravelTableTestCase
         $html = view('laravel-table::' . $table->getTbodyTemplatePath(), compact('table'))->toHtml();
         foreach ($users as $user) {
             $this->assertStringNotContainsString('<form class="show-' . $user->id, $html);
-            $this->assertStringNotContainsString('action="http://localhost/users/show?' . $user->id . '"', $html);
+            $this->assertStringNotContainsString('href="http://localhost/users/show?' . $user->id . '"', $html);
         }
     }
 
@@ -258,9 +258,9 @@ class RoutesTest extends LaravelTableTestCase
         $table->column('name');
         $table->configure();
         $html = view('laravel-table::' . $table->getTbodyTemplatePath(), compact('table'))->toHtml();
-        $this->assertStringContainsString('action="http://localhost/user/edit/' . $user->id . '"', $html);
+        $this->assertStringContainsString('href="http://localhost/user/show/' . $user->id . '"', $html);
+        $this->assertStringContainsString('href="http://localhost/user/edit/' . $user->id . '"', $html);
         $this->assertStringContainsString('action="http://localhost/user/destroy/' . $user->id . '"', $html);
-        $this->assertStringContainsString('action="http://localhost/user/show/' . $user->id . '"', $html);
     }
 
     public function testSetImplicitBindingRoutes()
@@ -279,9 +279,9 @@ class RoutesTest extends LaravelTableTestCase
         $table->column('name');
         $table->configure();
         $html = view('laravel-table::' . $table->getTbodyTemplatePath(), compact('table'))->toHtml();
-        $this->assertStringContainsString('action="http://localhost/user/edit/' . $user->id . '"', $html);
+        $this->assertStringContainsString('href="http://localhost/user/show/' . $user->id . '"', $html);
+        $this->assertStringContainsString('href="http://localhost/user/edit/' . $user->id . '"', $html);
         $this->assertStringContainsString('action="http://localhost/user/destroy/' . $user->id . '"', $html);
-        $this->assertStringContainsString('action="http://localhost/user/show/' . $user->id . '"', $html);
     }
 
     public function testSetRouteDefinitionWithProvidedIdAndOtherRouteParams()
@@ -303,7 +303,7 @@ class RoutesTest extends LaravelTableTestCase
         $table->configure();
         $html = view('laravel-table::' . $table->getTbodyTemplatePath(), compact('table'))->toHtml();
         $this->assertStringContainsString(
-            'action="http://localhost/parent/11/user/edit/' . $user->id . '/child/33"',
+            'href="http://localhost/parent/11/user/edit/' . $user->id . '/child/33"',
             $html
         );
         $this->assertStringContainsString(
@@ -311,7 +311,7 @@ class RoutesTest extends LaravelTableTestCase
             $html
         );
         $this->assertStringContainsString(
-            'action="http://localhost/parent/11/user/show/' . $user->id . '/child/33',
+            'href="http://localhost/parent/11/user/show/' . $user->id . '/child/33',
             $html
         );
     }
@@ -335,7 +335,7 @@ class RoutesTest extends LaravelTableTestCase
         $table->configure();
         $html = view('laravel-table::' . $table->getTbodyTemplatePath(), compact('table'))->toHtml();
         $this->assertStringContainsString(
-            'action="http://localhost/parent/11/user/edit/' . $user->id . '/child/33"',
+            'href="http://localhost/parent/11/user/edit/' . $user->id . '/child/33"',
             $html
         );
         $this->assertStringContainsString(
@@ -343,7 +343,7 @@ class RoutesTest extends LaravelTableTestCase
             $html
         );
         $this->assertStringContainsString(
-            'action="http://localhost/parent/11/user/show/' . $user->id . '/child/33',
+            'href="http://localhost/parent/11/user/show/' . $user->id . '/child/33',
             $html
         );
     }

--- a/tests/Unit/RowDisableTest.php
+++ b/tests/Unit/RowDisableTest.php
@@ -46,13 +46,13 @@ class RowDisableTest extends LaravelTableTestCase
             if ($user->id === 1 || $user->id === 2) {
                 $this->assertStringNotContainsString('edit-' . $user->id, $html);
                 $this->assertStringNotContainsString(
-                    'action="http://localhost/users/edit?' . $user->id . '"',
+                    'href="http://localhost/users/edit?' . $user->id . '"',
                     $html
                 );
             } else {
                 $this->assertStringContainsString('edit-' . $user->id, $html);
                 $this->assertStringContainsString(
-                    'action="http://localhost/users/edit?' . $user->id . '"',
+                    'href="http://localhost/users/edit?' . $user->id . '"',
                     $html
                 );
             }
@@ -87,12 +87,12 @@ class RowDisableTest extends LaravelTableTestCase
             if ($user->id === 1 || $user->id === 2) {
                 $this->assertStringNotContainsString('edit-' . $user->id, $html);
                 $this->assertStringNotContainsString(
-                    'action="http://localhost/users/edit?' . $user->id . '"',
+                    'href="http://localhost/users/edit?' . $user->id . '"',
                     $html
                 );
             } else {
                 $this->assertStringContainsString('edit-' . $user->id, $html);
-                $this->assertStringContainsString('action="http://localhost/users/edit?' . $user->id . '"', $html);
+                $this->assertStringContainsString('href="http://localhost/users/edit?' . $user->id . '"', $html);
             }
         }
     }

--- a/tests/Unit/RowsNumberTest.php
+++ b/tests/Unit/RowsNumberTest.php
@@ -38,7 +38,7 @@ class RowsNumberTest extends LaravelTableTestCase
         $table->column('email');
         $table->configure();
         $html = view('laravel-table::' . $table->getTheadTemplatePath(), compact('table'))->toHtml();
-        $this->assertStringNotContainsString('rows-number-selection', $html);
+        $this->assertStringNotContainsString('rows-number-definition', $html);
         $this->assertStringNotContainsString('type="hidden" name="search"', $html);
         $this->assertStringNotContainsString(
             'placeholder="Number of rows"',

--- a/tests/Unit/RowsNumberTest.php
+++ b/tests/Unit/RowsNumberTest.php
@@ -9,7 +9,7 @@ use Okipa\LaravelTable\Test\Models\User;
 
 class RowsNumberTest extends LaravelTableTestCase
 {
-    public function testSetRowsNumberSelectionActivationAttribute()
+    public function testSetRowsNumberDefinitionActivationAttribute()
     {
         $table = (new Table)->activateRowsNumberDefinition();
         $this->assertTrue($table->getRowsNumberDefinitionActivation());
@@ -61,7 +61,7 @@ class RowsNumberTest extends LaravelTableTestCase
         $table->column('email');
         $table->configure();
         $html = view('laravel-table::' . $table->getTheadTemplatePath(), compact('table'))->toHtml();
-        $this->assertStringNotContainsString('rows-number-selection', $html);
+        $this->assertStringNotContainsString('rows-number-definition', $html);
         $this->assertStringNotContainsString('type="hidden" name="search"', $html);
         $this->assertStringNotContainsString(
             'placeholder="Number of rows"',
@@ -73,7 +73,7 @@ class RowsNumberTest extends LaravelTableTestCase
         );
     }
 
-    public function testActivateRowsNumberSelectionHtml()
+    public function testActivateRowsNumberDefinitionHtml()
     {
         config()->set('laravel-table.behavior.activate_rows_number_definition', false);
         $this->routes(['users'], ['index']);
@@ -84,7 +84,7 @@ class RowsNumberTest extends LaravelTableTestCase
         $table->column('email');
         $table->configure();
         $html = view('laravel-table::' . $table->getTheadTemplatePath(), compact('table'))->toHtml();
-        $this->assertStringContainsString('rows-number-selection', $html);
+        $this->assertStringContainsString('rows-number-definition', $html);
         $this->assertStringContainsString('type="hidden" name="search"', $html);
         $this->assertStringContainsString(
             'placeholder="Number of rows"',

--- a/tests/Unit/TemplatesCustomizationsTest.php
+++ b/tests/Unit/TemplatesCustomizationsTest.php
@@ -29,11 +29,11 @@ class TemplatesCustomizationsTest extends LaravelTableTestCase
         $this->assertEquals($templatePath, $table->getRowsSearchingTemplatePath());
     }
 
-    public function testSetRowsNumberSelectionTemplateAttribute()
+    public function testSetrowsNumberDefinitionTemplateAttribute()
     {
-        $templatePath = 'rows-number-selection-test';
-        $table = (new Table)->model(User::class)->rowsNumberSelectionTemplate($templatePath);
-        $this->assertEquals($templatePath, $table->getRowsNumberSelectionTemplatePath());
+        $templatePath = 'rows-number-definition-test';
+        $table = (new Table)->model(User::class)->rowsNumberDefinitionTemplate($templatePath);
+        $this->assertEquals($templatePath, $table->getrowsNumberDefinitionTemplatePath());
     }
 
     public function testSetCreateTemplateAttribute()
@@ -148,18 +148,18 @@ class TemplatesCustomizationsTest extends LaravelTableTestCase
         $this->assertStringContainsString('<form id="rows-searching-test"></form>', $html);
     }
 
-    public function testSetRowsNumberSelectionTemplateHtml()
+    public function testSetrowsNumberDefinitionTemplateHtml()
     {
         view()->addNamespace('laravel-table', 'tests/views');
         $this->createMultipleUsers(2);
         $this->routes(['users'], ['index']);
         $table = (new Table)->model(User::class)
             ->routes(['index' => ['name' => 'users.index']])
-            ->rowsNumberSelectionTemplate('rows-number-selection-test');
+            ->rowsNumberDefinitionTemplate('rows-number-definition-test');
         $table->column('name');
         $table->configure();
-        $html = view('laravel-table::' . $table->getRowsNumberSelectionTemplatePath(), compact('table'))->toHtml();
-        $this->assertStringContainsString('<form id="rows-number-selection-test"></form>', $html);
+        $html = view('laravel-table::' . $table->getrowsNumberDefinitionTemplatePath(), compact('table'))->toHtml();
+        $this->assertStringContainsString('<form id="rows-number-definition-test"></form>', $html);
     }
 
     public function testSetCreateTemplateHtml()

--- a/tests/views/rows-number-definition-test.blade.php
+++ b/tests/views/rows-number-definition-test.blade.php
@@ -1,0 +1,1 @@
+<form id="rows-number-definition-test"></form>

--- a/tests/views/rows-number-selection-test.blade.php
+++ b/tests/views/rows-number-selection-test.blade.php
@@ -1,1 +1,0 @@
-<form id="rows-number-selection-test"></form>


### PR DESCRIPTION
* Reverted the previous change (3.0.1) as the `button` method without arguments has no visual effect: added instructions in V2 to v3 the upgrade-guide to take care of this new behaviour.
* Fixed an issue where create action button was not displayed when searching and rows number definition were disabled.
* Fixed a v3 regression where `rows number definition` was wrongly named `rows number selection` at different places (config, templates, methods, ...): this is an unfortunately breaking change if you published config or templates but I take advantage of the early release of the V3 and from the fact that Laravel 8 is not released to do it.
* Show and edit actions are now triggered by a simple link rather than a form, which was useless as these routes are called with a `GET` http request.
* Minor default templates changes in order to give laravel-table a prettier look.
* Minor default config value changes in order to give laravel-table a prettier look.****