### PR TITLE
Fixed issue #54

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [3.1.1](https://github.com/Okipa/laravel-table/compare/3.1.0...3.1.1)
+
+2020-08-24
+
+* Fixed column cell value not escaped when using `$column->value()` method (https://github.com/Okipa/laravel-table/issues/54).
+
 ## [3.1.0](https://github.com/Okipa/laravel-table/compare/3.0.1...3.1.0)
 
 2020-08-24

--- a/resources/views/bootstrap/tbody.blade.php
+++ b/resources/views/bootstrap/tbody.blade.php
@@ -58,7 +58,7 @@
                                         : null }}
                                 {{-- basic value --}}
                                 @else
-                                    {!! $value !!}
+                                    {{ $value }}
                                 @endif
                                 {{-- append --}}
                                 @if($showAppend)


### PR DESCRIPTION
* Fixed column cell value not escaped when using `$column->value()` method (https://github.com/Okipa/laravel-table/issues/54).