### PR TITLE
Fix pagination link margin bottom

### DIFF
--- a/resources/views/bootstrap/pagination.blade.php
+++ b/resources/views/bootstrap/pagination.blade.php
@@ -1,3 +1,3 @@
-<div class="d-flex align-items-center mb-n3 px-3 py-1 pagination-container">
+<div class="d-flex align-items-center px-3 py-1 pagination-container">
     {!! $table->getPaginator()->links() !!}
 </div>


### PR DESCRIPTION
The default `mb-n3`  pushes the margin down.

![image](https://user-images.githubusercontent.com/5412360/101380274-583ced00-38c6-11eb-97a7-e9f8ec7b4dc2.png)

Removing it seems to fix the issue

![image](https://user-images.githubusercontent.com/5412360/101380399-7e628d00-38c6-11eb-8e56-8cefac3771bb.png)