### PR TITLE
Add type property

### DIFF
--- a/src/Console/Commands/MakeTable.php
+++ b/src/Console/Commands/MakeTable.php
@@ -10,6 +10,13 @@ use Symfony\Component\Console\Input\InputOption;
 class MakeTable extends GeneratorCommand
 {
     /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'Table';
+    
+    /**
      * The console command name.
      *
      * @var string


### PR DESCRIPTION
This is necessary to generate correct messages:
- `Table already exists!`
- `Table created successfully.`