### PR TITLE
Fixed appending array to paginator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [4.0.5](https://github.com/Okipa/laravel-table/compare/4.0.4...4.0.5)
+
+2022-03-01
+
+* Fixed error when appending array to table with the `appendData` method
+
 ## [4.0.4](https://github.com/Okipa/laravel-table/compare/4.0.3...4.0.4)
 
 2021-08-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 2022-03-01
 
-* Fixed error when appending array to table with the `appendData` method
+* Fixed error when appending array data to table with the `appendData` method
+  * Data is now appended with hidden input to rows-number-definition-form and to search-form from the table `getGeneratedHiddenFields` method which is now returning html and not an array as before
+  * You may have to update your `rows-number-definition.blade.php` and `rows-searching.blade.php` view if you have published them
 
 ## [4.0.4](https://github.com/Okipa/laravel-table/compare/4.0.3...4.0.4)
 

--- a/resources/views/bootstrap/rows-number-definition.blade.php
+++ b/resources/views/bootstrap/rows-number-definition.blade.php
@@ -1,12 +1,9 @@
 @if($table->getRowsNumberDefinitionActivation())
     <div class="px-xl-3 py-1 rows-number-definition">
-        <form role="form" method="GET" action="{{ $table->getRoute('index') }}">
+        <form role="form" method="GET" action="{{ $table->getRoute('index') . '?' . http_build_query($table->getAppendedToPaginator()) }}">
             <input type="hidden" name="{{ $table->getSearchField() }}" value="{{ $table->getRequest()->get($table->getSearchField()) }}">
             <input type="hidden" name="{{ $table->getSortByField() }}" value="{{ $table->getRequest()->get($table->getSortByField()) }}">
             <input type="hidden" name="{{ $table->getSortDirField() }}" value="{{ $table->getRequest()->get($table->getSortDirField()) }}">
-            @foreach($table->getGeneratedHiddenFields() as $appendedKey => $appendedValue)
-                <input type="hidden" name="{{ $appendedKey }}" value="{{ $appendedValue }}">
-            @endforeach
             <div class="input-group">
                 <div class="input-group-prepend">
                     <span class="input-group-text text-secondary">

--- a/resources/views/bootstrap/rows-number-definition.blade.php
+++ b/resources/views/bootstrap/rows-number-definition.blade.php
@@ -1,9 +1,10 @@
 @if($table->getRowsNumberDefinitionActivation())
     <div class="px-xl-3 py-1 rows-number-definition">
-        <form role="form" method="GET" action="{{ $table->getRoute('index') . '?' . http_build_query($table->getAppendedToPaginator()) }}">
+        <form role="form" method="GET" action="{{ $table->getRoute('index') }}">
             <input type="hidden" name="{{ $table->getSearchField() }}" value="{{ $table->getRequest()->get($table->getSearchField()) }}">
             <input type="hidden" name="{{ $table->getSortByField() }}" value="{{ $table->getRequest()->get($table->getSortByField()) }}">
             <input type="hidden" name="{{ $table->getSortDirField() }}" value="{{ $table->getRequest()->get($table->getSortDirField()) }}">
+            {!! $table->getGeneratedHiddenFields() !!}}
             <div class="input-group">
                 <div class="input-group-prepend">
                     <span class="input-group-text text-secondary">

--- a/resources/views/bootstrap/rows-searching.blade.php
+++ b/resources/views/bootstrap/rows-searching.blade.php
@@ -1,12 +1,9 @@
 @if($table->getSearchableColumns()->count())
     <div class="flex-fill pr-xl-3 py-1 searching">
-        <form role="form" method="GET" action="{{ $table->getRoute('index') }}">
+        <form role="form" method="GET" action="{{ $table->getRoute('index') . '?' . http_build_query($table->getAppendedToPaginator()) }}">
             <input type="hidden" name="{{ $table->getRowsNumberField() }}" value="{{ $table->getRequest()->get($table->getRowsNumberField()) }}">
             <input type="hidden" name="{{ $table->getSortByField() }}" value="{{ $table->getRequest()->get($table->getSortByField()) }}">
             <input type="hidden" name="{{ $table->getSortDirField() }}" value="{{ $table->getRequest()->get($table->getSortDirField()) }}">
-            @foreach($table->getGeneratedHiddenFields() as $appendedKey => $appendedValue)
-                <input type="hidden" name="{{ $appendedKey }}" value="{{ $appendedValue }}">
-            @endforeach
             <div class="input-group">
                 <div class="input-group-prepend">
                     <span class="input-group-text text-secondary">

--- a/resources/views/bootstrap/rows-searching.blade.php
+++ b/resources/views/bootstrap/rows-searching.blade.php
@@ -1,9 +1,10 @@
 @if($table->getSearchableColumns()->count())
     <div class="flex-fill pr-xl-3 py-1 searching">
-        <form role="form" method="GET" action="{{ $table->getRoute('index') . '?' . http_build_query($table->getAppendedToPaginator()) }}">
+        <form role="form" method="GET" action="{{ $table->getRoute('index') }}">
             <input type="hidden" name="{{ $table->getRowsNumberField() }}" value="{{ $table->getRequest()->get($table->getRowsNumberField()) }}">
             <input type="hidden" name="{{ $table->getSortByField() }}" value="{{ $table->getRequest()->get($table->getSortByField()) }}">
             <input type="hidden" name="{{ $table->getSortDirField() }}" value="{{ $table->getRequest()->get($table->getSortDirField()) }}">
+            {!! $table->getGeneratedHiddenFields() !!}}
             <div class="input-group">
                 <div class="input-group-prepend">
                     <span class="input-group-text text-secondary">

--- a/tests/Unit/PaginationTest.php
+++ b/tests/Unit/PaginationTest.php
@@ -4,35 +4,21 @@ namespace Okipa\LaravelTable\Tests\Unit;
 
 use Okipa\LaravelTable\Table;
 use Okipa\LaravelTable\Test\LaravelTableTestCase;
-use Okipa\LaravelTable\Test\Models\User;
 
 class PaginationTest extends LaravelTableTestCase
 {
     public function testAppendData(): void
     {
-        $appended = ['foo' => 'bar', 'baz' => ['qux', 'quux'], 7 => 'corge'];
+        $appended = [
+            'foo' => 'bar',
+            'baz' => [
+                'qux',
+                'quux' => 'corge',
+                'grault',
+            ],
+            7 => 'garply',
+        ];
         $table = (new Table())->appendData($appended);
         self::assertEquals($table->getAppendedToPaginator(), $appended);
-        self::assertEquals($table->getGeneratedHiddenFields(), $appended);
-    }
-
-    public function testAppendDataHtml(): void
-    {
-        $this->routes(['users'], ['index']);
-        $appended = ['foo' => 'bar', 'baz' => ['qux', 'quux'], 7 => 'corge'];
-        $table = (new Table())->routes(['index' => ['name' => 'users.index']])
-            ->model(User::class)
-            ->appendData($appended);
-        $table->column('name')->title('Name')->searchable();
-        $table->configure();
-        $rowsNumberDefinitionHtml = view(
-            'laravel-table::' . $table->getrowsNumberDefinitionTemplatePath(),
-            compact('table')
-        )->toHtml();
-        self::assertStringContainsString(
-            '<form role="form" method="GET" action="' . $table->getRoute('index')
-            . '?' . e(http_build_query($table->getAppendedToPaginator())),
-            $rowsNumberDefinitionHtml
-        );
     }
 }

--- a/tests/Unit/PaginationTest.php
+++ b/tests/Unit/PaginationTest.php
@@ -10,7 +10,7 @@ class PaginationTest extends LaravelTableTestCase
 {
     public function testAppendData(): void
     {
-        $appended = ['foo' => 'bar', 'baz' => 'qux', 'quux_corge' => 'grault garply', 'waldo'];
+        $appended = ['foo' => 'bar', 'baz' => ['qux', 'quux'], 7 => 'corge'];
         $table = (new Table())->appendData($appended);
         self::assertEquals($table->getAppendedToPaginator(), $appended);
         self::assertEquals($table->getGeneratedHiddenFields(), $appended);
@@ -19,7 +19,7 @@ class PaginationTest extends LaravelTableTestCase
     public function testAppendDataHtml(): void
     {
         $this->routes(['users'], ['index']);
-        $appended = ['foo' => 'bar', 'baz' => 'qux', 'quux_corge' => 'grault garply', 'waldo'];
+        $appended = ['foo' => 'bar', 'baz' => ['qux', 'quux'], 7 => 'corge'];
         $table = (new Table())->routes(['index' => ['name' => 'users.index']])
             ->model(User::class)
             ->appendData($appended);
@@ -29,23 +29,10 @@ class PaginationTest extends LaravelTableTestCase
             'laravel-table::' . $table->getrowsNumberDefinitionTemplatePath(),
             compact('table')
         )->toHtml();
-        self::assertStringContainsString('<input type="hidden" name="foo" value="bar">', $rowsNumberDefinitionHtml);
-        self::assertStringContainsString('<input type="hidden" name="baz" value="qux">', $rowsNumberDefinitionHtml);
         self::assertStringContainsString(
-            '<input type="hidden" name="quux_corge" value="grault garply">',
+            '<form role="form" method="GET" action="' . $table->getRoute('index')
+            . '?' . e(http_build_query($table->getAppendedToPaginator())),
             $rowsNumberDefinitionHtml
         );
-        self::assertStringContainsString('<input type="hidden" name="0" value="waldo">', $rowsNumberDefinitionHtml);
-        $rowsSearchingHtml = view(
-            'laravel-table::' . $table->getRowsSearchingTemplatePath(),
-            compact('table')
-        )->toHtml();
-        self::assertStringContainsString('<input type="hidden" name="foo" value="bar">', $rowsSearchingHtml);
-        self::assertStringContainsString('<input type="hidden" name="baz" value="qux">', $rowsSearchingHtml);
-        self::assertStringContainsString(
-            '<input type="hidden" name="quux_corge" value="grault garply">',
-            $rowsSearchingHtml
-        );
-        self::assertStringContainsString('<input type="hidden" name="0" value="waldo">', $rowsSearchingHtml);
     }
 }

--- a/tests/Unit/RowsNumberTest.php
+++ b/tests/Unit/RowsNumberTest.php
@@ -156,4 +156,32 @@ class RowsNumberTest extends LaravelTableTestCase
             self::assertStringContainsString($user->email, $html);
         }
     }
+
+    public function testGenerateHiddenFieldsOnRowsNumberFormHtml(): void
+    {
+        $this->routes(['users'], ['index']);
+        $appended = [
+            'foo' => 'bar',
+            'baz' => [
+                'qux',
+                'quux' => 'corge',
+                'grault'
+            ],
+            7 => 'garply',
+        ];
+        $table = (new Table())->routes(['index' => ['name' => 'users.index']])
+            ->model(User::class)
+            ->appendData($appended);
+        $table->column('name')->title('Name')->searchable();
+        $table->configure();
+        $rowsNumberHtml = view(
+            'laravel-table::' . $table->getRowsNumberDefinitionTemplatePath(),
+            compact('table')
+        )->toHtml();
+        self::assertStringContainsString('<input type="hidden" name="foo" value="bar">', $rowsNumberHtml);
+        self::assertStringContainsString('<input type="hidden" name="baz[0]" value="qux">', $rowsNumberHtml);
+        self::assertStringContainsString('<input type="hidden" name="baz[quux]" value="corge">', $rowsNumberHtml);
+        self::assertStringContainsString('<input type="hidden" name="baz[1]" value="grault">', $rowsNumberHtml);
+        self::assertStringContainsString('<input type="hidden" name="7" value="garply">', $rowsNumberHtml);
+    }
 }

--- a/tests/Unit/SearchTest.php
+++ b/tests/Unit/SearchTest.php
@@ -494,4 +494,24 @@ class SearchTest extends LaravelTableTestCase
         $table->configure();
         self::assertTrue($user->is($table->getPaginator()->getCollection()->first()));
     }
+
+    public function testAppendDataHtml(): void
+    {
+        $this->routes(['users'], ['index']);
+        $appended = ['foo' => 'bar', 'baz' => ['qux', 'quux'], 7 => 'corge'];
+        $table = (new Table())->routes(['index' => ['name' => 'users.index']])
+            ->model(User::class)
+            ->appendData($appended);
+        $table->column('name')->title('Name')->searchable();
+        $table->configure();
+        $rowsNumberDefinitionHtml = view(
+            'laravel-table::' . $table->getRowsSearchingTemplatePath(),
+            compact('table')
+        )->toHtml();
+        self::assertStringContainsString(
+            '<form role="form" method="GET" action="' . $table->getRoute('index')
+            . '?' . e(http_build_query($table->getAppendedToPaginator())),
+            $rowsNumberDefinitionHtml
+        );
+    }
 }


### PR DESCRIPTION
* Fixed error when appending array data to table with the `appendData` method
  * Data is now appended with hidden input to rows-number-definition-form and to search-form from the table `getGeneratedHiddenFields` method which is now returning html and not an array as before
  * You may have to update your `rows-number-definition.blade.php` and `rows-searching.blade.php` view if you have published them