### PR TITLE
4.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [4.0.5](https://github.com/Okipa/laravel-table/compare/4.0.4...4.0.5)
+
+2022-03-10
+
+* Updated column `dateTimeFormat` method signature to `dateTimeFormat(string $dateTimeFormat, string $timezone = null): \Okipa\LaravelTable\Column`
+* If no timezone is set, the default one, defined in `config('app.timezone')` is used
+
 ## [4.0.4](https://github.com/Okipa/laravel-table/compare/4.0.3...4.0.4)
 
 2021-08-17

--- a/README.md
+++ b/README.md
@@ -84,8 +84,8 @@ class UsersTable extends AbstractTable
         $table->column('id')->sortable(true);
         $table->column('name')->sortable()->searchable();
         $table->column('email')->sortable()->searchable();
-        $table->column('created_at')->dateTimeFormat('d/m/Y H:i')->sortable();
-        $table->column('updated_at')->dateTimeFormat('d/m/Y H:i')->sortable();
+        $table->column('created_at')->dateTimeFormat('d/m/Y H:i', 'Europe/Paris')->sortable();
+        $table->column('updated_at')->dateTimeFormat('d/m/Y H:i', 'Europe/Paris')->sortable();
     }
 }
 ```
@@ -304,9 +304,9 @@ class NewsTable extends AbstractTable
             ->title(__('Display'))
             ->link(fn(News $news) => route('news.show', $news))
             ->button(['btn', 'btn-sm', 'btn-primary']);
-        $table->column('created_at')->dateTimeFormat('d/m/Y H:i')->sortable();
-        $table->column('updated_at')->dateTimeFormat('d/m/Y H:i')->sortable();
-        $table->column('published_at')->dateTimeFormat('d/m/Y H:i')->sortable(true, 'desc');
+        $table->column('created_at')->dateTimeFormat('d/m/Y H:i', 'Europe/Paris')->sortable();
+        $table->column('updated_at')->dateTimeFormat('d/m/Y H:i', 'Europe/Paris')->sortable();
+        $table->column('published_at')->dateTimeFormat('d/m/Y H:i', 'Europe/Paris')->sortable(true, 'desc');
     }
 
     protected function resultLines(Table $table): void
@@ -1068,17 +1068,18 @@ $table->column('company')->searchable('companiesAliasedTable', ['name', 'activit
 <h3 id="column-dateTimeFormat">dateTimeFormat</h3>
 
 > Set the format for a datetime, date or time database column (optional).  
-> (Carbon::parse($value)->format($format) method is used under the hood).
+> (Carbon::parse($value)->timezone($timezone)->->format($format) method is used under the hood).
 
 **Note:**
 
-* Signature: `dateTimeFormat(string $dateTimeFormat): \Okipa\LaravelTable\Column`
+* Signature: `dateTimeFormat(string $dateTimeFormat, string $timezone = null): \Okipa\LaravelTable\Column`
 * Optional
+* If no timezone is set, the default one, defined in `config('app.timezone')` is used
 
 **Use case example:**
 
 ```php
-$table->column('created_at')->dateTimeFormat('d/m/Y H:i');
+$table->column('created_at')->dateTimeFormat('d/m/Y H:i', 'Europe/Paris');
 ```
 
 <h3 id="column-button">button</h3>

--- a/resources/views/bootstrap/rows-number-definition.blade.php
+++ b/resources/views/bootstrap/rows-number-definition.blade.php
@@ -1,12 +1,9 @@
 @if($table->getRowsNumberDefinitionActivation())
     <div class="px-xl-3 py-1 rows-number-definition">
-        <form role="form" method="GET" action="{{ $table->getRoute('index') }}">
+        <form role="form" method="GET" action="{{ $table->getRoute('index') . '?' . http_build_query($table->getAppendedToPaginator()) }}">
             <input type="hidden" name="{{ $table->getSearchField() }}" value="{{ $table->getRequest()->get($table->getSearchField()) }}">
             <input type="hidden" name="{{ $table->getSortByField() }}" value="{{ $table->getRequest()->get($table->getSortByField()) }}">
             <input type="hidden" name="{{ $table->getSortDirField() }}" value="{{ $table->getRequest()->get($table->getSortDirField()) }}">
-            @foreach($table->getGeneratedHiddenFields() as $appendedKey => $appendedValue)
-                <input type="hidden" name="{{ $appendedKey }}" value="{{ $appendedValue }}">
-            @endforeach
             <div class="input-group">
                 <div class="input-group-prepend">
                     <span class="input-group-text text-secondary">

--- a/resources/views/bootstrap/rows-searching.blade.php
+++ b/resources/views/bootstrap/rows-searching.blade.php
@@ -1,12 +1,9 @@
 @if($table->getSearchableColumns()->count())
     <div class="flex-fill pr-xl-3 py-1 searching">
-        <form role="form" method="GET" action="{{ $table->getRoute('index') }}">
+        <form role="form" method="GET" action="{{ $table->getRoute('index') . '?' . http_build_query($table->getAppendedToPaginator()) }}">
             <input type="hidden" name="{{ $table->getRowsNumberField() }}" value="{{ $table->getRequest()->get($table->getRowsNumberField()) }}">
             <input type="hidden" name="{{ $table->getSortByField() }}" value="{{ $table->getRequest()->get($table->getSortByField()) }}">
             <input type="hidden" name="{{ $table->getSortDirField() }}" value="{{ $table->getRequest()->get($table->getSortDirField()) }}">
-            @foreach($table->getGeneratedHiddenFields() as $appendedKey => $appendedValue)
-                <input type="hidden" name="{{ $appendedKey }}" value="{{ $appendedValue }}">
-            @endforeach
             <div class="input-group">
                 <div class="input-group-prepend">
                     <span class="input-group-text text-secondary">

--- a/resources/views/bootstrap/tbody.blade.php
+++ b/resources/views/bootstrap/tbody.blade.php
@@ -54,7 +54,7 @@
                                 {{-- Datetime format --}}
                                 @elseif($column->getDateTimeFormat())
                                     {{ $value
-                                        ? \Carbon\Carbon::parse($value)->format($column->getDateTimeFormat())
+                                        ? \Carbon\Carbon::parse($value)->timezone($column->getTimezone())->format($column->getDateTimeFormat())
                                         : null }}
                                 {{-- Basic value --}}
                                 @else

--- a/src/Traits/Column/HasDateTimeFormat.php
+++ b/src/Traits/Column/HasDateTimeFormat.php
@@ -8,9 +8,12 @@ trait HasDateTimeFormat
 {
     protected ?string $dateTimeFormat = null;
 
-    public function dateTimeFormat(string $dateTimeFormat): Column
+    protected ?string $timezone = null;
+
+    public function dateTimeFormat(string $dateTimeFormat, string $timezone = null): Column
     {
         $this->dateTimeFormat = $dateTimeFormat;
+        $this->timezone = $timezone;
 
         /** @var \Okipa\LaravelTable\Column $this */
         return $this;
@@ -19,5 +22,10 @@ trait HasDateTimeFormat
     public function getDateTimeFormat(): ?string
     {
         return $this->dateTimeFormat;
+    }
+
+    public function getTimezone(): string
+    {
+        return $this->timezone ?: config('app.timezone');
     }
 }

--- a/tests/Unit/DateTimeTest.php
+++ b/tests/Unit/DateTimeTest.php
@@ -4,16 +4,17 @@ namespace Okipa\LaravelTable\Tests\Unit;
 
 use Carbon\Carbon;
 use Okipa\LaravelTable\Table;
-use Okipa\LaravelTable\Test\Models\User;
 use Okipa\LaravelTable\Test\LaravelTableTestCase;
+use Okipa\LaravelTable\Test\Models\User;
 
 class DateTimeTest extends LaravelTableTestCase
 {
     public function testDateFormatAttribute(): void
     {
         $table = (new Table())->model(User::class);
-        $table->column('name')->dateTimeFormat('d/m/Y H:i:s');
+        $table->column('name')->dateTimeFormat('d/m/Y H:i:s', 'Europe/Paris');
         self::assertEquals('d/m/Y H:i:s', $table->getColumns()->first()->getDateTimeFormat());
+        self::assertEquals('Europe/Paris', $table->getColumns()->first()->getTimezone());
     }
 
     public function testDateFormatHtml(): void
@@ -22,10 +23,10 @@ class DateTimeTest extends LaravelTableTestCase
         $user = $this->createUniqueUser();
         $table = (new Table())->model(User::class)->routes(['index' => ['name' => 'users.index', 'params' => []]]);
         $table->column('name');
-        $table->column('updated_at')->dateTimeFormat('d/m/Y');
+        $table->column('updated_at')->dateTimeFormat('d/m/Y', 'Europe/Paris');
         $table->configure();
         $html = view('laravel-table::' . $table->getTbodyTemplatePath(), compact('table'))->toHtml();
-        self::assertStringContainsString(Carbon::parse($user->updated_at)->format('d/m/Y'), $html);
+        self::assertStringContainsString($user->updated_at->timezone('Europe/Paris')->format('d/m/Y'), $html);
     }
 
     public function testDateTimeFormatAttribute(): void
@@ -33,6 +34,7 @@ class DateTimeTest extends LaravelTableTestCase
         $table = (new Table())->model(User::class);
         $table->column('name')->dateTimeFormat('H:i');
         self::assertEquals('H:i', $table->getColumns()->first()->getDateTimeFormat());
+        self::assertEquals('UTC', $table->getColumns()->first()->getTimezone());
     }
 
     public function testSetColumnDateTimeToDateFormatHtml(): void
@@ -53,10 +55,12 @@ class DateTimeTest extends LaravelTableTestCase
         $user = $this->createUniqueUser();
         $table = (new Table())->model(User::class)->routes(['index' => ['name' => 'users.index', 'params' => []]]);
         $table->column('name');
-        $table->column('updated_at')->dateTimeFormat('H\h i\m\i\n');
+        $table->column('updated_at')->dateTimeFormat('H\h i\m\i\n', 'Europe/Paris');
         $table->configure();
         $html = view('laravel-table::' . $table->getTbodyTemplatePath(), compact('table'))->toHtml();
-        self::assertStringContainsString(Carbon::parse($user->updated_at)->format('H\h i\m\i\n'), $html);
+        self::assertStringContainsString(Carbon::parse($user->updated_at)
+            ->timezone('Europe/Paris')
+            ->format('H\h i\m\i\n'), $html);
     }
 
     public function testSetColumnDateTimeToDateTimeFormatHtml(): void
@@ -65,9 +69,11 @@ class DateTimeTest extends LaravelTableTestCase
         $user = $this->createUniqueUser();
         $table = (new Table())->model(User::class)->routes(['index' => ['name' => 'users.index', 'params' => []]]);
         $table->column('name');
-        $table->column('updated_at')->dateTimeFormat('d/m/Y H:i');
+        $table->column('updated_at')->dateTimeFormat('d/m/Y H:i', 'Europe/Paris');
         $table->configure();
         $html = view('laravel-table::' . $table->getTbodyTemplatePath(), compact('table'))->toHtml();
-        self::assertStringContainsString(Carbon::parse($user->updated_at)->format('d/m/Y H:i'), $html);
+        self::assertStringContainsString(Carbon::parse($user->updated_at)
+            ->timezone('Europe/Paris')
+            ->format('d/m/Y H:i'), $html);
     }
 }

--- a/tests/Unit/PaginationTest.php
+++ b/tests/Unit/PaginationTest.php
@@ -10,7 +10,7 @@ class PaginationTest extends LaravelTableTestCase
 {
     public function testAppendData(): void
     {
-        $appended = ['foo' => 'bar', 'baz' => 'qux', 'quux_corge' => 'grault garply', 'waldo'];
+        $appended = ['foo' => 'bar', 'baz' => ['qux', 'quux'], 7 => 'corge'];
         $table = (new Table())->appendData($appended);
         self::assertEquals($table->getAppendedToPaginator(), $appended);
         self::assertEquals($table->getGeneratedHiddenFields(), $appended);
@@ -19,7 +19,7 @@ class PaginationTest extends LaravelTableTestCase
     public function testAppendDataHtml(): void
     {
         $this->routes(['users'], ['index']);
-        $appended = ['foo' => 'bar', 'baz' => 'qux', 'quux_corge' => 'grault garply', 'waldo'];
+        $appended = ['foo' => 'bar', 'baz' => ['qux', 'quux'], 7 => 'corge'];
         $table = (new Table())->routes(['index' => ['name' => 'users.index']])
             ->model(User::class)
             ->appendData($appended);
@@ -29,23 +29,10 @@ class PaginationTest extends LaravelTableTestCase
             'laravel-table::' . $table->getrowsNumberDefinitionTemplatePath(),
             compact('table')
         )->toHtml();
-        self::assertStringContainsString('<input type="hidden" name="foo" value="bar">', $rowsNumberDefinitionHtml);
-        self::assertStringContainsString('<input type="hidden" name="baz" value="qux">', $rowsNumberDefinitionHtml);
         self::assertStringContainsString(
-            '<input type="hidden" name="quux_corge" value="grault garply">',
+            '<form role="form" method="GET" action="' . $table->getRoute('index')
+            . '?' . e(http_build_query($table->getAppendedToPaginator())),
             $rowsNumberDefinitionHtml
         );
-        self::assertStringContainsString('<input type="hidden" name="0" value="waldo">', $rowsNumberDefinitionHtml);
-        $rowsSearchingHtml = view(
-            'laravel-table::' . $table->getRowsSearchingTemplatePath(),
-            compact('table')
-        )->toHtml();
-        self::assertStringContainsString('<input type="hidden" name="foo" value="bar">', $rowsSearchingHtml);
-        self::assertStringContainsString('<input type="hidden" name="baz" value="qux">', $rowsSearchingHtml);
-        self::assertStringContainsString(
-            '<input type="hidden" name="quux_corge" value="grault garply">',
-            $rowsSearchingHtml
-        );
-        self::assertStringContainsString('<input type="hidden" name="0" value="waldo">', $rowsSearchingHtml);
     }
 }

--- a/tests/Unit/SearchTest.php
+++ b/tests/Unit/SearchTest.php
@@ -494,4 +494,24 @@ class SearchTest extends LaravelTableTestCase
         $table->configure();
         self::assertTrue($user->is($table->getPaginator()->getCollection()->first()));
     }
+
+    public function testAppendDataHtml(): void
+    {
+        $this->routes(['users'], ['index']);
+        $appended = ['foo' => 'bar', 'baz' => ['qux', 'quux'], 7 => 'corge'];
+        $table = (new Table())->routes(['index' => ['name' => 'users.index']])
+            ->model(User::class)
+            ->appendData($appended);
+        $table->column('name')->title('Name')->searchable();
+        $table->configure();
+        $rowsNumberDefinitionHtml = view(
+            'laravel-table::' . $table->getRowsSearchingTemplatePath(),
+            compact('table')
+        )->toHtml();
+        self::assertStringContainsString(
+            '<form role="form" method="GET" action="' . $table->getRoute('index')
+            . '?' . e(http_build_query($table->getAppendedToPaginator())),
+            $rowsNumberDefinitionHtml
+        );
+    }
 }


### PR DESCRIPTION
* Updated column `dateTimeFormat` method signature to `dateTimeFormat(string $dateTimeFormat, string $timezone = null): \Okipa\LaravelTable\Column`
* If no timezone is set, the default one, defined in `config('app.timezone')` is used