### PR TITLE
5.1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,8 +59,6 @@ jobs:
       - name: Code analysis
         if: matrix.php == '8.1' && matrix.laravel == '9.*'
         run: |
-          # Remove this line once Larastan and Livewire are working well together
-          sed -i -e 's#.*protected \$enablesPackageDiscoveries.*#&\nprotected function overrideApplicationBindings($app){return["livewire"=>"Livewire\\\\LivewireManager"];}#' vendor/nunomaduro/larastan/src/ApplicationResolver.php
           vendor/bin/pint --test -vvv
           vendor/bin/phpmd config,src,tests text phpmd.xml
           vendor/bin/phpstan analyse

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [5.1.0](https://github.com/Okipa/laravel-table/compare/5.0.2...5.1.0)
+
+2022-10-25
+ 
+* Added ability to chain a `->when(bool $condition)` method to an instantiated head action, in order to enable it conditionally
+* Added a new built-in `RedirectHeadAction`, that will be used by the pre-configured `CreateHeadAction`
+* Added an optional `bool $openInNewWindow = false` to the `CreateHeadAction`
+* Added a new [JavaScript snippet](/README.md#set-up-a-few-lines-of-javascript) to handle head action link opening in tab: you'll have to add it if you want to benefit from this new ability
+
 ## [5.0.2](https://github.com/Okipa/laravel-table/compare/5.0.1...5.0.2)
 
 2022-10-07

--- a/README.md
+++ b/README.md
@@ -480,7 +480,7 @@ This package provides the following built-in head actions:
     * Requires `string $createUrl` and `bool $openInNewWindow = false` arguments on instantiation
     * Instantiate a pre-configured `RedirectHeadAction` with the given `$createUrl` as URL, `__('Create')` as label and `config('laravel-table.icon.create')` as icon
 
-To use on of them, you'll have to pass an instance of it to the `headAction` method.
+To use one of them, you'll have to pass an instance of it to the `headAction` method.
 
 You'll ben able to chain the following method to your head action:
 * `when(bool $condition): Okipa\LaravelTable\Abstracts\AbstractHeadAction`

--- a/README.md
+++ b/README.md
@@ -473,11 +473,18 @@ Configure a table action that will be displayed as a button positioned at the ri
 If no head action is declared, the dedicated slot for it in the table head will remain empty.
 
 This package provides the following built-in head actions:
-* `CreateHeadAction`:
-    * Requires a `string $createUrl` argument on instantiation
+* `RedirectHeadAction`:
+    * Requires `string $url`, `string $label`, `string $icon`, `array $class = ['btn', 'btn-success']` and `bool $openInNewWindow = false` arguments on instantiation
     * Redirects to the model create page from a click on a `Create` button
+* `CreateHeadAction`:
+    * Requires `string $createUrl` and `bool $openInNewWindow = false` arguments on instantiation
+    * Instantiate a pre-configured `RedirectHeadAction` with the given `$createUrl` as URL, `__('Create')` as label and `config('laravel-table.icon.create')` as icon
 
-To use it, you'll have to pass an instance of it to the `headAction` method.
+To use on of them, you'll have to pass an instance of it to the `headAction` method.
+
+You'll ben able to chain the following method to your head action:
+* `when(bool $condition): Okipa\LaravelTable\Abstracts\AbstractHeadAction`
+    * Determines whether the head action should be enabled
 
 ```php
 namespace App\Tables;
@@ -493,7 +500,8 @@ class UsersTable extends AbstractTableConfiguration
     {
         return Table::make()
             ->model(User::class)
-            ->headAction(new CreateHeadAction(route('user.create')));
+            // Create head action will not be available when authenticated user is not allowed to create users
+            ->headAction((new CreateHeadAction(route('user.create')))->when(Auth::user()->cannot('create_users')));
     }
 }
 ```
@@ -551,7 +559,7 @@ To use them, you'll have to pass a closure parameter to the `bulkActions` method
 
 You'll ben able to chain the following methods to your bulk actions:
 * `when(bool $condition): Okipa\LaravelTable\Abstracts\AbstractBulkAction`
-    * Determines if action should be available on table rows
+    * Determines whether the bulk action should be enabled on the table rows
 * `confirmationQuestion(string|false $confirmationQuestion): Okipa\LaravelTable\Abstracts\AbstractBulkAction`
     * Overrides the default action confirmation message
 * `feedbackMessage(string|false $feedbackMessage): Okipa\LaravelTable\Abstracts\AbstractBulkAction`:
@@ -1182,6 +1190,14 @@ Following the same logic, you'll have to intercept it from a JS script as shown 
 Livewire.on('laraveltable:action:feedback', (feedbackMessage) => {
     // Replace this native JS alert by your favorite modal/alert/toast library implementation. Or keep it this way!
     window.alert(feedbackMessage);
+});
+```
+
+Finally, in order to allow head `RedirectHeadAction` and `CreateHeadAction` to open link in new tab, you'll also have to add the following JS snippet:
+
+```javascript
+Livewire.on('laraveltable:link:open:newtab', (url) => {
+    window.open(url, '_blank').focus();
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -482,7 +482,7 @@ This package provides the following built-in head actions:
 
 To use one of them, you'll have to pass an instance of it to the `headAction` method.
 
-You'll ben able to chain the following method to your head action:
+You'll be able to chain the following method to your head action:
 * `when(bool $condition): Okipa\LaravelTable\Abstracts\AbstractHeadAction`
     * Determines whether the head action should be enabled
 
@@ -557,7 +557,7 @@ This package provides the built-in following bulk actions:
 
 To use them, you'll have to pass a closure parameter to the `bulkActions` method. This closure will allow you to manipulate a `Illuminate\Database\Eloquent $model` argument and has to return an array containing bulk action instances.
 
-You'll ben able to chain the following methods to your bulk actions:
+You'll be able to chain the following methods to your bulk actions:
 * `when(bool $condition): Okipa\LaravelTable\Abstracts\AbstractBulkAction`
     * Determines whether the bulk action should be enabled on the table rows
 * `confirmationQuestion(string|false $confirmationQuestion): Okipa\LaravelTable\Abstracts\AbstractBulkAction`

--- a/src/Abstracts/AbstractHeadAction.php
+++ b/src/Abstracts/AbstractHeadAction.php
@@ -9,11 +9,25 @@ abstract class AbstractHeadAction
 {
     public string $rowActionClass;
 
+    protected bool $isAllowed = true;
+
     abstract protected function class(): array;
 
     abstract protected function icon(): string;
 
     abstract protected function title(): string;
+
+    public function when(bool $condition): self
+    {
+        $this->isAllowed = $condition;
+
+        return $this;
+    }
+
+    public function isAllowed(): bool
+    {
+        return $this->isAllowed;
+    }
 
     /** @return mixed|void */
     abstract public function action(Component $livewire);

--- a/src/HeadActions/CreateHeadAction.php
+++ b/src/HeadActions/CreateHeadAction.php
@@ -2,35 +2,40 @@
 
 namespace Okipa\LaravelTable\HeadActions;
 
-use Illuminate\Http\RedirectResponse;
 use Livewire\Component;
-use Livewire\Redirector;
 use Okipa\LaravelTable\Abstracts\AbstractHeadAction;
 
 class CreateHeadAction extends AbstractHeadAction
 {
-    public function __construct(public string $createUrl)
+    protected RedirectHeadAction $redirectHeadAction;
+
+    public function __construct(public string $createUrl, bool $openInNewWindow = false)
     {
-        //
+        $this->redirectHeadAction = new RedirectHeadAction(
+            url: $createUrl,
+            label: __('Create'),
+            icon: config('laravel-table.icon.create'),
+            openInNewWindow: $openInNewWindow
+        );
     }
 
     protected function class(): array
     {
-        return ['btn', 'btn-success'];
+        return $this->redirectHeadAction->class();
     }
 
     protected function title(): string
     {
-        return __('Create');
+        return $this->redirectHeadAction->title();
     }
 
     protected function icon(): string
     {
-        return config('laravel-table.icon.create');
+        return $this->redirectHeadAction->icon();
     }
 
-    public function action(Component $livewire): RedirectResponse|Redirector
+    public function action(Component $livewire): void
     {
-        return redirect()->to($this->createUrl);
+        $this->redirectHeadAction->action($livewire);
     }
 }

--- a/src/HeadActions/RedirectHeadAction.php
+++ b/src/HeadActions/RedirectHeadAction.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Okipa\LaravelTable\HeadActions;
+
+use Livewire\Component;
+use Okipa\LaravelTable\Abstracts\AbstractHeadAction;
+
+class RedirectHeadAction extends AbstractHeadAction
+{
+    public function __construct(
+        public string $url,
+        public string $label,
+        public string $icon,
+        public array $class = ['btn', 'btn-success'],
+        public bool $openInNewWindow = false,
+    ) {
+        //
+    }
+
+    protected function class(): array
+    {
+        return $this->class;
+    }
+
+    protected function title(): string
+    {
+        return __($this->label);
+    }
+
+    protected function icon(): string
+    {
+        return $this->icon;
+    }
+
+    public function action(Component $livewire): void
+    {
+        $this->openInNewWindow
+            ? $livewire->emit('laraveltable:link:open:newtab', $this->url)
+            : redirect()->to($this->url);
+    }
+}

--- a/src/Livewire/Table.php
+++ b/src/Livewire/Table.php
@@ -52,7 +52,7 @@ class Table extends Component
 
     public bool $resetFilters = false;
 
-    public array|null $headActionArray;
+    public array $headActionArray;
 
     public bool $selectAll = false;
 
@@ -233,7 +233,15 @@ class Table extends Component
 
     public function headAction(): mixed
     {
-        return AbstractHeadAction::make($this->headActionArray)->action($this);
+        if (! $this->headActionArray) {
+            return null;
+        }
+        $headActionInstance = AbstractHeadAction::make($this->headActionArray);
+        if (! $headActionInstance->isAllowed()) {
+            return null;
+        }
+
+        return $headActionInstance->action($this);
     }
 
     public function updatedSelectAll(): void

--- a/src/Table.php
+++ b/src/Table.php
@@ -354,16 +354,20 @@ class Table
         return $filterClosures;
     }
 
-    public function getHeadActionArray(): array|null
+    public function getHeadActionArray(): array
     {
         if (! $this->headAction) {
-            return null;
+            return [];
         }
         $this->headAction->setup();
+        if (! $this->headAction->isAllowed()) {
+            return [];
+        }
 
         return (array) $this->headAction;
     }
 
+    /** @throws \JsonException */
     public function getRowClass(): array
     {
         $tableRowClass = [];
@@ -374,7 +378,10 @@ class Table
             $tableRowClass[$model->laravel_table_unique_identifier] = ($this->rowClassesClosure)($model);
         }
 
-        return $tableRowClass;
+        return json_decode(json_encode(
+            $tableRowClass,
+            JSON_THROW_ON_ERROR
+        ), true, 512, JSON_THROW_ON_ERROR);
     }
 
     /** @throws \JsonException */


### PR DESCRIPTION
* Added ability to chain a `->when(bool $condition)` method to an instantiated head action, in order to enable it conditionally
* Added a new built-in `RedirectHeadAction`, that will be used by the pre-configured `CreateHeadAction`
* Added an optional `bool $openInNewWindow = false` to the `CreateHeadAction`
* Added a new [JavaScript snippet](/README.md#set-up-a-few-lines-of-javascript) to handle head action link opening in tab: you'll have to add it if you want to benefit from this new ability

Fixes https://github.com/Okipa/laravel-table/discussions/100.