### PR TITLE
Fixed reordering feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [5.1.1](https://github.com/Okipa/laravel-table/compare/5.1.0...5.1.1)
+
+2022-10-26
+
+* Fixed [reordering feature](/README.md#allow-columns-to-be-reordered-from-drag-and-drop-action) that was not compatible with packages like [spatie/eloquent-sortable](https://github.com/spatie/eloquent-sortable) (which authorize several model entries to have the same position when the sorting does group models from a query => [example](https://github.com/spatie/eloquent-sortable#grouping))
+
 ## [5.1.0](https://github.com/Okipa/laravel-table/compare/5.0.2...5.1.0)
 
 2022-10-25

--- a/README.md
+++ b/README.md
@@ -1091,6 +1091,8 @@ class UsersTable extends AbstractTableConfiguration
 }
 ```
 
+Tip: if you are using packages like [spatie/eloquent-sortable](https://github.com/spatie/eloquent-sortable) to handle your Eloquent models sorting behaviour with a [grouping query](https://github.com/spatie/eloquent-sortable#grouping), you'll have to also set this grouping query in the [table query instruction](#add-query-instructions-on-tables).
+
 ### Declare results on tables
 
 To display results, you'll have to return an array of result instances from the `results` method available in your generated table configuration.

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -14,6 +14,8 @@ parameters:
     ignoreErrors:
         - '#Parameter \#1 \$callback of method Illuminate\\Database\\Eloquent\\Factories\\Factory<Illuminate\\Database\\Eloquent\\Model>::afterCreating\(\)#'
         - '#Access to an undefined property Tests\\Models\\User::\$active#'
+        - '#Access to an undefined property Tests\\Models\\UserCategory::\$position#'
+        - '#Access to an undefined property Tests\\Models\\Company::\$position#'
         - '#Call to an undefined method Faker\\Generator::catchphrase\(\)#'
         - '#Access to an undefined property Illuminate\\Database\\Eloquent\\Model::\$laravel_table_unique_identifier#'
 

--- a/src/Filters/ValueFilter.php
+++ b/src/Filters/ValueFilter.php
@@ -5,7 +5,6 @@ namespace Okipa\LaravelTable\Filters;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Arr;
 use Okipa\LaravelTable\Abstracts\AbstractFilter;
-use Tests\Models\User;
 
 class ValueFilter extends AbstractFilter
 {
@@ -41,6 +40,5 @@ class ValueFilter extends AbstractFilter
     public function filter(Builder $query, mixed $selected): void
     {
         $query->whereIn($this->attribute, Arr::wrap($selected));
-//        dd($query->toSql(), $selected, User::pluck('name')->toArray());
     }
 }


### PR DESCRIPTION
* Fixed [reordering feature](/README.md#allow-columns-to-be-reordered-from-drag-and-drop-action) that was not compatible with packages like [spatie/eloquent-sortable](https://github.com/spatie/eloquent-sortable) (which authorize several model entries to have the same position when the sorting does group models from a query => [example](https://github.com/spatie/eloquent-sortable#grouping))