### PR TITLE
5.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+All notable changes to this package will be documented in this file.
+
+## [5.2.0](https://github.com/Okipa/laravel-table/compare/5.1.2...5.2.0)
+
+2022-10-28
+
+* Added a new built-in `RedirectShowAction`, that will be used by the pre-configured `ShowRowAction`
+* 
+
 ## [5.1.2](https://github.com/Okipa/laravel-table/compare/5.1.1...5.1.2)
 
 2022-10-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this package will be documented in this file.
 2022-10-28
 
 * Added a new built-in `RedirectRowAction`, that is now used to render the pre-configured `ShowRowAction`
+* Added an optional second argument `bool $openInNewWindow = false` to the `ShowRowAction`
 * Added a new pre-configured `AddHeadAction`, that is using the built-in `RedirectHeadAction`
   * Added a new `Add` translation for it that you'll have to add to [your own translations](/README.md#translations)
   * Added a new `config('laravel-table.icon.add')` config for it with the `<i class="fa-solid fa-circle-plus fa-fw"></i>` default value that you'll also have to add to [your published configuration file](/README.md#configuration)
@@ -30,7 +31,7 @@ All notable changes to this package will be documented in this file.
  
 * Added ability to chain a `->when(bool $condition)` method to an instantiated head action, in order to enable it conditionally
 * Added a new built-in `RedirectHeadAction`, that is now used to render the pre-configured `CreateHeadAction`
-* Added an optional `bool $openInNewWindow = false` to the `CreateHeadAction`
+* Added an optional second argument `bool $openInNewWindow = false` to the `CreateHeadAction`
 * Added a new [JavaScript snippet](/README.md#set-up-a-few-lines-of-javascript) to handle head action link opening in tab: you'll have to add it if you want to benefit from this new ability
 
 ## [5.0.2](https://github.com/Okipa/laravel-table/compare/5.0.1...5.0.2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ All notable changes to this package will be documented in this file.
 * Added a new pre-configured `AddHeadAction`, that is using the built-in `RedirectHeadAction`
   * Added a new `Add` translation for it that you'll have to add to [your own translations](/README.md#translations)
   * Added a new `config('laravel-table.icon.add')` config for it with the `<i class="fa-solid fa-circle-plus fa-fw"></i>` default value that you'll also have to add to [your published configuration file](/README.md#configuration)
-* 
 
 ## [5.1.2](https://github.com/Okipa/laravel-table/compare/5.1.1...5.1.2)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ All notable changes to this package will be documented in this file.
 
 2022-10-28
 
-* Added a new built-in `RedirectShowAction`, that will be used by the pre-configured `ShowRowAction`
+* Added a new built-in `RedirectRowAction`, that is now used to render the pre-configured `ShowRowAction`
+* Added a new pre-configured `AddHeadAction`, that is using the built-in `RedirectHeadAction`
+  * Added a new `Add` translation for it that you'll have to add to [your own translations](/README.md#translations)
+  * Added a new `config('laravel-table.icon.add')` config for it with the `<i class="fa-solid fa-circle-plus fa-fw"></i>` default value that you'll also have to add to [your published configuration file](/README.md#configuration)
 * 
 
 ## [5.1.2](https://github.com/Okipa/laravel-table/compare/5.1.1...5.1.2)
@@ -27,7 +30,7 @@ All notable changes to this package will be documented in this file.
 2022-10-25
  
 * Added ability to chain a `->when(bool $condition)` method to an instantiated head action, in order to enable it conditionally
-* Added a new built-in `RedirectHeadAction`, that will be used by the pre-configured `CreateHeadAction`
+* Added a new built-in `RedirectHeadAction`, that is now used to render the pre-configured `CreateHeadAction`
 * Added an optional `bool $openInNewWindow = false` to the `CreateHeadAction`
 * Added a new [JavaScript snippet](/README.md#set-up-a-few-lines-of-javascript) to handle head action link opening in tab: you'll have to add it if you want to benefit from this new ability
 

--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ Status
 * `Actions`
 * `Bulk Actions`
 * `Create`
+* `Add`
 * `Show`
 * `Edit`
 * `Destroy`
@@ -475,10 +476,10 @@ If no head action is declared, the dedicated slot for it in the table head will 
 This package provides the following built-in head actions:
 * `RedirectHeadAction`:
     * Requires `string $url`, `string $label`, `string $icon`, `array $class = ['btn', 'btn-success']` and `bool $openInNewWindow = false` arguments on instantiation
-    * Redirects to the model create page from a click on a `Create` button
+    * Redirects to the given URL from a click on the button
 * `CreateHeadAction`:
     * Requires `string $createUrl` and `bool $openInNewWindow = false` arguments on instantiation
-    * Instantiate a pre-configured `RedirectHeadAction` with the given `$createUrl` as URL, `__('Create')` as label and `config('laravel-table.icon.create')` as icon
+    * Instantiate a pre-configured `RedirectHeadAction` with `$createUrl` as URL, `__('Create')` as label and `config('laravel-table.icon.create')` as icon
 
 To use one of them, you'll have to pass an instance of it to the `headAction` method.
 
@@ -491,7 +492,7 @@ namespace App\Tables;
 
 use App\Models\User;
 use Okipa\LaravelTable\Table;
-use Okipa\LaravelTable\HeadActions\CreateHeadAction;
+use Okipa\LaravelTable\HeadActions\AddHeadAction;
 use Okipa\LaravelTable\Abstracts\AbstractTableConfiguration;
 
 class UsersTable extends AbstractTableConfiguration
@@ -501,7 +502,7 @@ class UsersTable extends AbstractTableConfiguration
         return Table::make()
             ->model(User::class)
             // Create head action will not be available when authenticated user is not allowed to create users
-            ->headAction((new CreateHeadAction(route('user.create')))->when(Auth::user()->cannot('create_users')));
+            ->headAction((new AddHeadAction(route('user.create')))->when(Auth::user()->cannot('create_users')));
     }
 }
 ```
@@ -638,9 +639,12 @@ If no row action is declared on your table, the dedicated `Actions` column at th
 **Important note:** [you'll have to set up a few lines of javascript](#set-up-a-few-lines-of-javascript) to allow row actions confirmation requests and feedback to be working properly.
 
 This package provides the built-in following row actions:
+* `RedirectRowAction`:
+    * Requires `string $url`, `string $title`, `string $icon`, `array $class = ['link-info']`, `string|null $defaultConfirmationQuestion = null`, `string|null $defaultFeedbackMessage = null` and `bool $openInNewWindow = false` arguments on instantiation
+    * Redirects to the given URL from a click on the link
 * `ShowRowAction`:
-  * Requires a `string $showUrl` argument on instantiation
-  * Redirects to the model edit page on click
+  * Requires `string $showUrl` and `bool $openInNewWindow = false` arguments on instantiation
+  * Instantiate a pre-configured `RedirectRowAction` with `$showUrl` as URL, `__('Show')` as label and `config('laravel-table.icon.show')` as icon
 * `EditRowAction`:
   * Requires a `string $editUrl` argument on instantiation
   * Redirects to the model edit page on click

--- a/config/laravel-table.php
+++ b/config/laravel-table.php
@@ -23,6 +23,7 @@ return [
         'info' => '<i class="fa-solid fa-circle-info"></i>',
         'reset' => '<i class="fa-solid fa-rotate-left"></i>',
         'drag_drop' => '<i class="fa-solid fa-grip-vertical"></i>',
+        'add' => '<i class="fa-solid fa-circle-plus fa-fw"></i>',
         'create' => '<i class="fa-solid fa-circle-plus fa-fw"></i>',
         'show' => '<i class="fa-solid fa-eye fa-fw"></i>',
         'edit' => '<i class="fa-solid fa-pencil fa-fw"></i>',

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -8,7 +8,7 @@ parameters:
         - src/
         - tests/
 
-    # The level 9 is the highest level
+    # Level 9 is the highest level
     level: 5
 
     databaseMigrationsPath:

--- a/src/Abstracts/AbstractRowAction.php
+++ b/src/Abstracts/AbstractRowAction.php
@@ -17,7 +17,7 @@ abstract class AbstractRowAction
 
     public string $identifier;
 
-    protected string|null $class;
+    protected array $class;
 
     protected string $icon;
 

--- a/src/HeadActions/AddHeadAction.php
+++ b/src/HeadActions/AddHeadAction.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Okipa\LaravelTable\HeadActions;
+
+use Livewire\Component;
+use Okipa\LaravelTable\Abstracts\AbstractHeadAction;
+
+class AddHeadAction extends AbstractHeadAction
+{
+    protected RedirectHeadAction $redirectHeadAction;
+
+    public function __construct(public string $createUrl, bool $openInNewWindow = false)
+    {
+        $this->redirectHeadAction = new RedirectHeadAction(
+            url: $createUrl,
+            label: __('Add'),
+            icon: config('laravel-table.icon.add'),
+            openInNewWindow: $openInNewWindow
+        );
+    }
+
+    protected function class(): array
+    {
+        return $this->redirectHeadAction->class();
+    }
+
+    protected function title(): string
+    {
+        return $this->redirectHeadAction->title();
+    }
+
+    protected function icon(): string
+    {
+        return $this->redirectHeadAction->icon();
+    }
+
+    public function action(Component $livewire): void
+    {
+        $this->redirectHeadAction->action($livewire);
+    }
+}

--- a/src/RowActions/RedirectRowAction.php
+++ b/src/RowActions/RedirectRowAction.php
@@ -3,10 +3,8 @@
 namespace Okipa\LaravelTable\RowActions;
 
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Str;
 use Livewire\Component;
-use Livewire\Redirector;
 use Okipa\LaravelTable\Abstracts\AbstractRowAction;
 
 class RedirectRowAction extends AbstractRowAction
@@ -19,8 +17,7 @@ class RedirectRowAction extends AbstractRowAction
         public string|null $defaultConfirmationQuestion = null,
         public string|null $defaultFeedbackMessage = null,
         public bool $openInNewWindow = false,
-    )
-    {
+    ) {
         //
     }
 

--- a/src/RowActions/RedirectRowAction.php
+++ b/src/RowActions/RedirectRowAction.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Okipa\LaravelTable\RowActions;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Str;
+use Livewire\Component;
+use Livewire\Redirector;
+use Okipa\LaravelTable\Abstracts\AbstractRowAction;
+
+class RedirectRowAction extends AbstractRowAction
+{
+    public function __construct(
+        public string $url,
+        public string $title,
+        public string $icon,
+        public array $class = ['link-info'],
+        public string|null $defaultConfirmationQuestion = null,
+        public string|null $defaultFeedbackMessage = null,
+        public bool $openInNewWindow = false,
+    )
+    {
+        //
+    }
+
+    protected function identifier(): string
+    {
+        return 'row_action_' . Str::snake($this->title);
+    }
+
+    protected function class(Model $model): array
+    {
+        return $this->class;
+    }
+
+    protected function icon(Model $model): string
+    {
+        return $this->icon;
+    }
+
+    protected function title(Model $model): string
+    {
+        return $this->title;
+    }
+
+    protected function defaultConfirmationQuestion(Model $model): string|null
+    {
+        return $this->defaultConfirmationQuestion;
+    }
+
+    protected function defaultFeedbackMessage(Model $model): string|null
+    {
+        return $this->defaultFeedbackMessage;
+    }
+
+    public function action(Model $model, Component $livewire): void
+    {
+        $this->openInNewWindow
+            ? $livewire->emit('laraveltable:link:open:newtab', $this->url)
+            : redirect()->to($this->url);
+    }
+}

--- a/src/RowActions/ShowRowAction.php
+++ b/src/RowActions/ShowRowAction.php
@@ -10,43 +10,50 @@ use Okipa\LaravelTable\Abstracts\AbstractRowAction;
 
 class ShowRowAction extends AbstractRowAction
 {
-    public function __construct(public string $showUrl)
+    protected RedirectRowAction $redirectRowAction;
+
+    public function __construct(public string $showUrl, public bool $openInNewWindow = false)
     {
-        //
+        $this->redirectRowAction = new RedirectRowAction(
+            url: $showUrl,
+            title: __('Show'),
+            icon: config('laravel-table.icon.show'),
+            openInNewWindow: $openInNewWindow
+        );
     }
 
     protected function identifier(): string
     {
-        return 'row_action_show';
+        return $this->redirectRowAction->identifier();
     }
 
     protected function class(Model $model): array
     {
-        return ['link-info'];
+        return $this->redirectRowAction->class($model);
     }
 
     protected function icon(Model $model): string
     {
-        return config('laravel-table.icon.show');
+        return $this->redirectRowAction->icon($model);
     }
 
     protected function title(Model $model): string
     {
-        return __('Show');
+        return $this->redirectRowAction->title($model);
     }
 
     protected function defaultConfirmationQuestion(Model $model): string|null
     {
-        return null;
+        return $this->redirectRowAction->defaultConfirmationQuestion($model);
     }
 
     protected function defaultFeedbackMessage(Model $model): string|null
     {
-        return null;
+        return $this->redirectRowAction->defaultFeedbackMessage($model);
     }
 
-    public function action(Model $model, Component $livewire): RedirectResponse|Redirector
+    public function action(Model $model, Component $livewire): void
     {
-        return redirect()->to($this->showUrl);
+        $this->redirectRowAction->action($model, $livewire);
     }
 }

--- a/src/RowActions/ShowRowAction.php
+++ b/src/RowActions/ShowRowAction.php
@@ -3,9 +3,7 @@
 namespace Okipa\LaravelTable\RowActions;
 
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Http\RedirectResponse;
 use Livewire\Component;
-use Livewire\Redirector;
 use Okipa\LaravelTable\Abstracts\AbstractRowAction;
 
 class ShowRowAction extends AbstractRowAction

--- a/tests/Unit/Bootstrap5/TableHeadActionTest.php
+++ b/tests/Unit/Bootstrap5/TableHeadActionTest.php
@@ -8,6 +8,7 @@ use Livewire\Livewire;
 use Okipa\LaravelTable\Abstracts\AbstractTableConfiguration;
 use Okipa\LaravelTable\Column;
 use Okipa\LaravelTable\HeadActions\AddHeadAction;
+use Okipa\LaravelTable\HeadActions\CreateHeadAction;
 use Okipa\LaravelTable\Table;
 use Tests\Models\User;
 use Tests\TestCase;
@@ -20,7 +21,7 @@ class TableHeadActionTest extends TestCase
     public function it_can_set_table_head_action(): void
     {
         app('router')->get('/user/create', ['as' => 'user.create']);
-        Config::set('laravel-table.icon.create', 'create-icon');
+        Config::set('laravel-table.icon.add', 'add-icon');
         $config = new class extends AbstractTableConfiguration
         {
             protected function table(): Table
@@ -42,8 +43,8 @@ class TableHeadActionTest extends TestCase
                 '<a wire:click.prevent="headAction()"',
                 ' class="btn btn-success"',
                 ' href=""',
-                ' title="Create">',
-                'create-icon Create',
+                ' title="Add">',
+                'add-icon Add',
                 '</a>',
             ])
             ->call('headAction')
@@ -60,7 +61,7 @@ class TableHeadActionTest extends TestCase
             protected function table(): Table
             {
                 return Table::make()->model(User::class)
-                    ->headAction((new AddHeadAction(route('user.create'), true))->when(false));
+                    ->headAction((new CreateHeadAction(route('user.create'), true))->when(false));
             }
 
             protected function columns(): array

--- a/tests/Unit/Bootstrap5/TableHeadActionTest.php
+++ b/tests/Unit/Bootstrap5/TableHeadActionTest.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Facades\Config;
 use Livewire\Livewire;
 use Okipa\LaravelTable\Abstracts\AbstractTableConfiguration;
 use Okipa\LaravelTable\Column;
-use Okipa\LaravelTable\HeadActions\CreateHeadAction;
+use Okipa\LaravelTable\HeadActions\AddHeadAction;
 use Okipa\LaravelTable\Table;
 use Tests\Models\User;
 use Tests\TestCase;
@@ -26,7 +26,7 @@ class TableHeadActionTest extends TestCase
             protected function table(): Table
             {
                 return Table::make()->model(User::class)
-                    ->headAction(new CreateHeadAction(route('user.create')));
+                    ->headAction(new AddHeadAction(route('user.create')));
             }
 
             protected function columns(): array
@@ -60,7 +60,7 @@ class TableHeadActionTest extends TestCase
             protected function table(): Table
             {
                 return Table::make()->model(User::class)
-                    ->headAction((new CreateHeadAction(route('user.create'), true))->when(false));
+                    ->headAction((new AddHeadAction(route('user.create'), true))->when(false));
             }
 
             protected function columns(): array


### PR DESCRIPTION
* Added a new built-in `RedirectRowAction`, that is now used to render the pre-configured `ShowRowAction`
* Added an optional second argument `bool $openInNewWindow = false` to the `ShowRowAction`
* Added a new pre-configured `AddHeadAction`, that is using the built-in `RedirectHeadAction`
  * Added a new `Add` translation for it that you'll have to add to [your own translations](/README.md#translations)
  * Added a new `config('laravel-table.icon.add')` config for it with the `<i class="fa-solid fa-circle-plus fa-fw"></i>` default value that you'll also have to add to [your published configuration file](/README.md#configuration)