### PR TITLE
Remove LOWER for pgsql driver because it's redundant

### DIFF
--- a/src/Table.php
+++ b/src/Table.php
@@ -211,7 +211,7 @@ class Table
 
     protected function getSqlLowerFunction(string $driver, string $attribute): string
     {
-        return $driver === 'pgsql' ? 'LOWER(CAST(' . $attribute . ' AS TEXT))' : 'LOWER(' . $attribute . ')';
+        return $driver === 'pgsql' ? 'CAST(' . $attribute . ' AS TEXT)' : 'LOWER(' . $attribute . ')';
     }
 
     protected function getSqlCaseInsensitiveSearchingLikeOperator(string $driver): string


### PR DESCRIPTION
Because you're forcing ILIKE when using the pgsql driver, you only need to cast to text and not lower. Lowering clobbers all indexes, making it impossible to improve query speeds. The below ILIKE when using pgsql takes care of lower and upper searches while still leaving the cast above for dates etc.