### PR TITLE
Stop table refresh on RedirectRowAction

### DIFF
--- a/src/RowActions/RedirectRowAction.php
+++ b/src/RowActions/RedirectRowAction.php
@@ -54,7 +54,7 @@ class RedirectRowAction extends AbstractRowAction
     public function action(Model $model, Component $livewire): void
     {
         $this->openInNewWindow
-            ? $livewire->emit('laraveltable:link:open:newtab', $this->url)
+            ? $livewire->emit('laraveltable:link:open:newtab', $this->url, $this->skipRender())
             : redirect()->to($this->url);
     }
 }


### PR DESCRIPTION
Prevent original table refresh when merely clicking a RedirectRowAction with openInNewWindow set to True, preventing unnecessary database queries.