### PR TITLE
Allow adding table header class

### DIFF
--- a/resources/views/bootstrap-4/table.blade.php
+++ b/resources/views/bootstrap-4/table.blade.php
@@ -146,7 +146,7 @@
                         @endif
                         {{-- Sorting/Column titles --}}
                         @foreach($columns as $column)
-                            <th wire:key="column-{{ Str::of($column->getAttribute())->snake('-')->slug() }}" class="align-middle {{ $column->getHeaderClass() }}" scope="col">
+                            <th wire:key="column-{{ Str::of($column->getAttribute())->snake('-')->slug() }}" class="align-middle{{ ($headerClass = $column->getHeaderClass()) ? ' '.$headerClass : '' }}" scope="col">
                                 @if($column->isSortable($orderColumn))
                                     @if($sortBy === $column->getAttribute())
                                         <a wire:click.prevent="sortBy('{{ $column->getAttribute() }}')"

--- a/resources/views/bootstrap-4/table.blade.php
+++ b/resources/views/bootstrap-4/table.blade.php
@@ -146,7 +146,7 @@
                         @endif
                         {{-- Sorting/Column titles --}}
                         @foreach($columns as $column)
-                            <th wire:key="column-{{ Str::of($column->getAttribute())->snake('-')->slug() }}" class="align-middle" scope="col">
+                            <th wire:key="column-{{ Str::of($column->getAttribute())->snake('-')->slug() }}" class="align-middle {{ $column->getHeaderClass() }}" scope="col">
                                 @if($column->isSortable($orderColumn))
                                     @if($sortBy === $column->getAttribute())
                                         <a wire:click.prevent="sortBy('{{ $column->getAttribute() }}')"

--- a/resources/views/bootstrap-5/table.blade.php
+++ b/resources/views/bootstrap-5/table.blade.php
@@ -138,7 +138,7 @@
                         @endif
                         {{-- Sorting/Column titles --}}
                         @foreach($columns as $column)
-                            <th wire:key="column-{{ Str::of($column->getAttribute())->snake('-')->slug() }}" class="align-middle {{ $column->getHeaderClass() }}" scope="col">
+                            <th wire:key="column-{{ Str::of($column->getAttribute())->snake('-')->slug() }}" class="align-middle{{ ($headerClass = $column->getHeaderClass()) ? ' '.$headerClass : '' }}" scope="col">
                                 @if($column->isSortable($orderColumn))
                                     @if($sortBy === $column->getAttribute())
                                         <a wire:click.prevent="sortBy('{{ $column->getAttribute() }}')"

--- a/resources/views/bootstrap-5/table.blade.php
+++ b/resources/views/bootstrap-5/table.blade.php
@@ -138,7 +138,7 @@
                         @endif
                         {{-- Sorting/Column titles --}}
                         @foreach($columns as $column)
-                            <th wire:key="column-{{ Str::of($column->getAttribute())->snake('-')->slug() }}" class="align-middle" scope="col">
+                            <th wire:key="column-{{ Str::of($column->getAttribute())->snake('-')->slug() }}" class="align-middle {{ $column->getHeaderClass() }}" scope="col">
                                 @if($column->isSortable($orderColumn))
                                     @if($sortBy === $column->getAttribute())
                                         <a wire:click.prevent="sortBy('{{ $column->getAttribute() }}')"

--- a/src/Column.php
+++ b/src/Column.php
@@ -23,6 +23,8 @@ class Column
 
     protected bool $searchable = false;
 
+    protected string|null $headerClass = null;
+
     protected Closure|null $searchableClosure = null;
 
     protected Closure|AbstractFormatter|null $formatter = null;
@@ -113,6 +115,18 @@ class Column
     public function isSearchable(): bool
     {
         return $this->searchable;
+    }
+
+    public function headerClass(string $headerClass): self
+    {
+        $this->headerClass = $headerClass;
+
+        return $this;
+    }
+
+    public function getHeaderClass(): string|null
+    {
+        return $this->headerClass;
     }
 
     public function getSearchableClosure(): Closure|null

--- a/tests/Unit/Bootstrap5/TableColumnsTest.php
+++ b/tests/Unit/Bootstrap5/TableColumnsTest.php
@@ -71,6 +71,40 @@ class TableColumnsTest extends TestCase
     }
 
     /** @test */
+    public function it_can_set_column_header_class(): void
+    {
+        $config = new class extends AbstractTableConfiguration
+        {
+            protected function table(): Table
+            {
+                return Table::make()->model(User::class);
+            }
+
+            protected function columns(): array
+            {
+                return [
+                    Column::make('id'),
+                    Column::make('name')->headerClass('test-header-class'),
+                ];
+            }
+        };
+        Livewire::test(\Okipa\LaravelTable\Livewire\Table::class, ['config' => $config::class])
+            ->call('init')
+            ->assertSeeHtmlInOrder([
+                '<thead>',
+                '<tr',
+                '<th wire:key="column-id" class="align-middle" scope="col">',
+                'validation.attributes.id',
+                '</th>',
+                '<th wire:key="column-name" class="align-middle test-header-class" scope="col">',
+                'validation.attributes.name',
+                '</th>',
+                '</tr>',
+                '</thead>',
+            ]);
+    }
+
+    /** @test */
     public function it_can_display_column_values(): void
     {
         $users = User::factory()->count(2)->create();


### PR DESCRIPTION
This PR proposes the introduction of a `headerClass` property in `\Okipa\LaravelTable\Column` that allows adding CSS classes to the main `<th>` elements.

# Validating this PR

1. From a `Column` object, call its `headerClass` method passing any string representing a CSS class, example: `Column::make('testProperty')->headerClass('my-custom-css-class')`
1. Open the page the table's being rendered and inspect the table's head element
1. The `testProperty` column `th` element has an additional class and it's now like this: `class="align-middle test-header-class"`
1. The `\Tests\Unit\Bootstrap5\TableColumnsTest::it_can_set_column_header_class()` is updated and also serves as an example of its usage

# Future considerations

* If approved, this solution may also be implemented to add CSS classes to `<td>`'s.